### PR TITLE
[mpi] MPI_Groups

### DIFF
--- a/include/mpi.h
+++ b/include/mpi.h
@@ -1,0 +1,176 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_LIBMPI_MPI_H_
+#define NANVIX_LIBMPI_MPI_H_
+
+/**
+ * @brief Maximum string sizes constants.
+ */
+#define MPI_MAX_DATAREP_STRING          64
+#define MPI_MAX_ERROR_STRING           128
+#define MPI_MAX_INFO_KEY                32
+#define MPI_MAX_INFO_VAL               256
+#define MPI_MAX_LIBRARY_VERSION_STRING 256
+#define MPI_MAX_OBJECT_NAME             64
+#define MPI_MAX_PORT_NAME              128
+#define MPI_MAX_PROCESSOR_NAME         128
+
+/* End of assorted constants. */
+
+/**
+ * @brief Assorted constants.
+ */
+#define MPI_PROC_NULL          (-2) /* Rank of null process.         */
+#define MPI_ANY_SOURCE         (-1) /* Any source rank.              */
+#define MPI_ANY_TAG            (-1) /* Match any message tag.        */
+#define MPI_UNDEFINED      (-32766) /* Undefined stuff.              */
+#define MPI_BSEND_OVERHEAD     128  /* Size of bsend header + ptr.   */
+#define MPI_KEYVAL_INVALID     (-1) /* Invalid key value.            */
+#define MPI_LOCK_EXCLUSIVE       1
+#define MPI_LOCK_SHARED          2
+#define MPI_ROOT               (-4) /* Special value for intercomms. */
+
+/* End of assorted constants. */
+
+/**
+ * @brief Results of the compare operations.
+ */
+#define MPI_IDENT     0
+#define MPI_CONGRUENT 1
+#define MPI_SIMILAR   2
+#define MPI_UNEQUAL   3
+
+/**
+ * @brief Error Codes and Classes.
+ */
+#define MPI_SUCCESS                    0 /* No error. */
+#define MPI_ERR_BUFFER                 1 /* Invalid buffer pointer. */
+#define MPI_ERR_COUNT                  2 /* Invalid count argument. */
+#define MPI_ERR_TYPE                   3 /* Invalid datatype argument. */
+#define MPI_ERR_TAG                    4 /* Invalid tag argument. */
+#define MPI_ERR_COMM                   5 /* Invalid communicator. */
+#define MPI_ERR_RANK                   6 /* Invalid rank. */
+#define MPI_ERR_REQUEST                7 /* Invalid request (handle). */
+#define MPI_ERR_ROOT                   8 /* Invalid root. */
+#define MPI_ERR_GROUP                  9 /* Invalid group. */
+#define MPI_ERR_OP                    10 /* Invalid operation. */
+#define MPI_ERR_TOPOLOGY              11 /* Invalid topology. */
+#define MPI_ERR_DIMS                  12 /* Invalid dimension argument. */
+#define MPI_ERR_ARG                   13 /* Invalid argument of other kind. */
+#define MPI_ERR_UNKNOWN               14 /* Unknown error. */
+#define MPI_ERR_TRUNCATE              15 /* Message truncated on receive. */
+#define MPI_ERR_OTHER                 16 /* Known error not in this list. */
+#define MPI_ERR_INTERN                17 /* Internal MPI impl error. */
+#define MPI_ERR_PENDING               18 /* Pending request. */
+#define MPI_ERR_IN_STATUS             19 /* Error code is in status. */
+#define MPI_ERR_ACCESS                20 /* Permission denied. */
+#define MPI_ERR_AMODE                 21 /* Error related to amode on I/O. */
+#define MPI_ERR_ASSERT                22 /* Invalid assert argument. */
+#define MPI_ERR_BAD_FILE              23 /* Invalid file name. */
+#define MPI_ERR_BASE                  24 /* Invalid base to MPI_FREE_MEM. */
+#define MPI_ERR_CONVERSION            25 /* Error in a user conv function. */
+#define MPI_ERR_DISP                  26 /* Invalid disp argument. */
+#define MPI_ERR_DUP_DATAREP           27 /* Already defined data representation. */
+#define MPI_ERR_FILE_EXISTS           28 /* File exists. */
+#define MPI_ERR_FILE_IN_USE           29 /* File currently open by some process. */
+#define MPI_ERR_FILE                  30 /* Invalid file handle. */
+#define MPI_ERR_INFO_KEY              31 /* Key longer than MPI_MAX_INFO_KEY. */
+#define MPI_ERR_INFO_NOKEY            32 /* Invalid key to MPI_INFO_DELETE. */
+#define MPI_ERR_INFO_VALUE            33 /* Value longer than MPI_MAX_INFO_VAL. */
+#define MPI_ERR_INFO                  34 /* Invalid info argument. */
+#define MPI_ERR_IO                    35 /* Other I/O error. */
+#define MPI_ERR_KEYVAL                36 /* Invalid keyval has been passed. */
+#define MPI_ERR_LOCKTYPE              37 /* Invalid locktype argument. */
+#define MPI_ERR_NAME                  38 /* Invalid srvc name to MPI_LOOKUP_NAME. */
+#define MPI_ERR_NO_MEM                39 /* Memory is exhausted. */
+#define MPI_ERR_NOT_SAME              40 /* Collective arg not identical on all procs. */
+#define MPI_ERR_NO_SPACE              41 /* Not enough space. */
+#define MPI_ERR_NO_SUCH_FILE          42 /* File does not exist. */
+#define MPI_ERR_PORT                  43 /* Invalid port name to MPI_COMM_CONNECT. */
+#define MPI_ERR_QUOTA                 44 /* Quota exceeded. */
+#define MPI_ERR_READ_ONLY             45 /* Read-only file or file system. */
+#define MPI_ERR_RMA_ATTACH            46
+#define MPI_ERR_RMA_CONFLICT          47 /* Conflicting accesses to window. */
+#define MPI_ERR_RMA_RANGE             48
+#define MPI_ERR_RMA_SHARED            49
+#define MPI_ERR_RMA_SYNC              50 /* Wrong synchronization of RMA calls. */
+#define MPI_ERR_RMA_FLAVOR            51
+#define MPI_ERR_SERVICE               52 /* Invalid srvc nameto MPI_UNPUBLISH_NAME. */
+#define MPI_ERR_SIZE                  53 /* Invalid size argument. */
+#define MPI_ERR_SPAWN                 54 /* Error in spawning processes. */
+#define MPI_ERR_UNSUPPORTED_DATAREP   55 /* Unsupp datarep to MPI_FILE_SET_VIEW. */
+#define MPI_ERR_UNSUPPORTED_OPERATION 56 /* Unsupported operation. */
+#define MPI_ERR_WIN                   57 /* Invalid win argument. */
+#define MPI_T_ERR_CANNOT_INIT         58
+#define MPI_T_ERR_NOT_INITIALIZED     59
+#define MPI_T_ERR_MEMORY              60
+#define MPI_T_ERR_INVALID             61
+#define MPI_T_ERR_INVALID_INDEX       62
+#define MPI_T_ERR_INVALID_ITEM        63
+#define MPI_T_ERR_INVALID_SESSION     64
+#define MPI_T_ERR_INVALID_HANDLE      65
+#define MPI_T_ERR_INVALID_NAME        66
+#define MPI_T_ERR_OUT_OF_HANDLES      67
+#define MPI_T_ERR_OUT_OF_SESSIONS     68
+#define MPI_T_ERR_CVAR_SET_NOT_NOW    69
+#define MPI_T_ERR_CVAR_SET_NEVER      70
+#define MPI_T_ERR_PVAR_NO_WRITE       71
+#define MPI_T_ERR_PVAR_NO_STARTSTOP   72
+#define MPI_T_ERR_PVAR_NO_ATOMIC      73
+
+/**
+ * @note Used to sanytize codes validity. Should gave some room for user added error codes.
+ */
+#define MPI_ERR_LASTCODE              92 /* Last error code . */
+
+/* End of error classes definitions. */
+
+/**
+ * @brief Supported thread levels constants.
+ */
+#define MPI_THREAD_SINGLE     0
+#define MPI_THREAD_FUNNELED   1
+#define MPI_THREAD_SERIALIZED 2
+#define MPI_THREAD_MULTIPLE   3
+
+/**
+ * @brief External predefined structures.
+ *
+ * @note These are global predefined structures exported as definitions below.
+ */
+extern struct mpi_group_t _mpi_group_empty;
+extern struct mpi_group_t _mpi_group_null;
+
+/**
+ * @brief Predefined handlers.
+ */
+#define MPI_GROUP_EMPTY &_mpi_group_empty
+
+/**
+ * @brief Null handlers.
+ */
+#define MPI_GROUP_NULL  &_mpi_group_null
+
+#endif /* NANVIX_LIBMPI_H_ */

--- a/include/mpi/group.h
+++ b/include/mpi/group.h
@@ -1,0 +1,122 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_MPI_GROUP_H_
+#define NANVIX_MPI_GROUP_H_
+
+#include <nanvix/hal.h>
+#include <mputil/object.h>
+#include <mputil/proc.h>
+#include <mpi.h>
+
+/**
+ * @brief Struct that defines a mpi_group.
+ */
+struct mpi_group_t
+{
+	object_t super;               /* Base object class.        */
+
+	int my_rank;                  /* Local rank inside group.  */
+	struct mpi_process_t **procs; /* Pointer to procs list.    */
+	int size;                     /* Nr of processes in group. */
+	struct mpi_group_t *parent;   /* Parent group pointer.     */
+};
+
+typedef struct mpi_group_t mpi_group_t;
+
+/* Class declaration. */
+OBJ_CLASS_DECLARATION(mpi_group_t);
+
+/**
+ * @brief Allocates a new group with @p group_size.
+ *
+ * @param group_size Number of processes that will be in the group.
+ *
+ * @returns Upon successful completion, the new group is returned.
+ * A NULL pointer is returned instead.
+ */
+extern mpi_group_t * mpi_group_allocate(int group_size);
+
+/**
+ * @brief Allocates a new group with @p group_size and proc_list defined.
+ *
+ * @param procs      List of processes to be initialized in the group.
+ * @param group_size Number of processes that will be in the group.
+ *
+ * @returns Upon successful completion, the new group is returned.
+ * A NULL pointer is returned instead.
+ */
+extern mpi_group_t * mpi_group_allocate_w_procs(mpi_process_t ** procs, int group_size);
+
+/**
+ * @brief Frees the specified group.
+ *
+ * @param group The group to be freed.
+ *
+ * @returns Upon successful completion, zero is returned. A negative error code is
+ * returned instead.
+ */
+extern int mpi_group_free(mpi_group_t ** group);
+
+/**
+ * @brief Gets the group size.
+ *
+ * @param group Group descriptor.
+ *
+ * @returns @p group size.
+ */
+static inline int mpi_group_size(mpi_group_t * group)
+{
+	return group->size;
+}
+
+/**
+ * @brief Gets the local process rank inside the given group.
+ *
+ * @param group Group descriptor.
+ *
+ * @returns The local process rank inside the group.
+ */
+static inline int mpi_group_rank(mpi_group_t * group)
+{
+	return group->my_rank;
+}
+
+/**
+ * @brief Initializes the groups submodule.
+ *
+ * @returns Upon successful completion, zero is returned. A
+ * negative error code is returned instead.
+ */
+extern int mpi_group_init(void);
+
+/**
+ * @brief Finalizes the groups submodule.
+ *
+ * @returns Upon successful completion, zero is returned. A
+ * negative error code is returned instead.
+ */
+extern int mpi_group_finalize(void);
+
+#endif /* NANVIX_MPI_GROUP_H_ */

--- a/src/mpi/group/group.c
+++ b/src/mpi/group/group.c
@@ -1,0 +1,243 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/hlib.h>
+#include <nanvix/ulib.h>
+#include <posix/errno.h>
+#include <mpi/group.h>
+
+PRIVATE void mpi_group_construct(mpi_group_t *);
+PRIVATE void mpi_group_destruct(mpi_group_t *);
+PRIVATE void mpi_group_increment_proc_count(mpi_group_t *);
+PRIVATE void mpi_group_decrement_proc_count(mpi_group_t *);
+
+OBJ_CLASS_INSTANCE(mpi_group_t, &mpi_group_construct, &mpi_group_destruct, sizeof(mpi_group_t));
+
+/**
+ * @brief Predefined groups (for effects of comparation).
+ */
+mpi_group_t _mpi_group_empty;
+mpi_group_t _mpi_group_null;
+
+/**
+ * @brief Group constructor.
+ */
+PRIVATE void mpi_group_construct(mpi_group_t * group)
+{
+	uassert(group != NULL);
+
+    group->my_rank = -1;
+    group->procs   = NULL;
+    group->size    = -1;
+    group->parent  = NULL;
+}
+
+/**
+ * @brief Group destructor.
+ */
+PRIVATE void mpi_group_destruct(mpi_group_t * group)
+{
+    uassert(group != NULL);
+
+    if (group->procs != NULL)
+    {
+    	mpi_group_decrement_proc_count(group);
+    	ufree(group->procs);
+    }
+
+    if (group->parent != NULL)
+    	OBJ_RELEASE(group->parent);
+}
+
+/**
+ * @brief Increments the refcount of each process in @p group.
+ *
+ * @param group Group of processes to be manipulated.
+ */
+PRIVATE void mpi_group_increment_proc_count(mpi_group_t * group)
+{
+	uassert(group != NULL);
+	uassert(group->size >= 0);
+
+	if (group->size == 0)
+		return;
+
+	/* Traverse the processes list. */
+	for (int i = 0; i < group->size; ++i)
+		OBJ_RETAIN(group->procs[i]);
+}
+
+/**
+ * @brief Decrements the refcount of each process in @p group.
+ *
+ * @param group Group of processes to be manipulated.
+ */
+PRIVATE void mpi_group_decrement_proc_count(mpi_group_t * group)
+{
+	uassert(group != NULL);
+	uassert(group->size >= 0);
+
+	if (group->size == 0)
+		return;
+
+	/* Traverse the processes list. */
+	for (int i = 0; i < group->size; ++i)
+		OBJ_RELEASE(group->procs[i]);
+}
+
+/**
+ * @brief Allocates a new group with @p group_size.
+ *
+ * @param group_size Number of processes that will be in the group.
+ *
+ * @returns Upon successful completion, the new group is returned.
+ * A NULL pointer is returned instead.
+ */
+PUBLIC mpi_group_t * mpi_group_allocate(int group_size)
+{
+	mpi_group_t * new_group;
+	mpi_process_t ** procs;
+
+	/* Bad group size. */
+	if (group_size < 0)
+		return (NULL);
+
+	if (group_size == 0)
+	{
+		OBJ_RETAIN(&_mpi_group_empty);
+		return (&_mpi_group_empty);
+	}
+
+	/* Allocates the processes list. */
+	procs = (mpi_process_t **) ucalloc(group_size, sizeof(mpi_process_t *));
+	if (procs == NULL)
+		return (NULL);
+
+	new_group = mpi_group_allocate_w_procs(procs, group_size);
+	if (new_group == NULL)
+		ufree(procs);
+	
+	return (new_group);
+}
+
+/**
+ * @brief Allocates a new group with @p group_size and proc_list defined.
+ *
+ * @param procs      List of processes to be initialized in the group.
+ * @param group_size Number of processes that will be in the group.
+ *
+ * @returns Upon successful completion, the new group is returned.
+ * A NULL pointer is returned instead.
+ */
+PUBLIC mpi_group_t * mpi_group_allocate_w_procs(mpi_process_t ** procs, int group_size)
+{
+	mpi_group_t * new_group;
+
+	/* Bad group size. */
+	if (group_size < 0)
+		return (NULL);
+
+	/* Bad processes list. */
+	if (procs == NULL)
+		return (NULL);
+
+	/* Allocates the new group. */
+	if (group_size == 0)
+	{
+		new_group = &_mpi_group_empty;
+		OBJ_RETAIN(new_group);
+	}
+	else
+	{
+		new_group = OBJ_NEW(mpi_group_t);
+		if (new_group == NULL)
+			return (NULL);
+
+		/* Initializes the group attributes. */
+		new_group->my_rank = MPI_UNDEFINED;
+		new_group->procs   = procs;
+		new_group->size    = group_size;
+		new_group->parent  = NULL;
+	}
+
+	return (new_group);
+}
+
+/**
+ * @brief Frees the specified group.
+ *
+ * @param group The group to be freed.
+ *
+ * @returns Upon successful completion, zero is returned and @p group
+ * set to point to MPI_PROC_NULL. A negative error code is returned
+ * instead.
+ */
+PUBLIC int mpi_group_free(mpi_group_t ** group)
+{
+	/* Bad group. */
+	if (*group == NULL)
+		return (-EINVAL);
+
+	OBJ_RELEASE(group);
+	*group = MPI_GROUP_NULL;
+
+	return (0);
+}
+
+/**
+ * @brief Initializes the groups submodule.
+ *
+ * @returns Upon successful completion, zero is returned. A
+ * negative error code is returned instead.
+ */
+PUBLIC int mpi_group_init(void)
+{
+	/* Initializes mpi_group_empty. */
+	OBJ_CONSTRUCT(&_mpi_group_empty, mpi_group_t);
+	_mpi_group_empty.my_rank = MPI_UNDEFINED;
+	_mpi_group_empty.size    = 0;
+
+	/* Initializes mpi_group_null. */
+	OBJ_CONSTRUCT(&_mpi_group_null, mpi_group_t);
+	_mpi_group_null.my_rank = MPI_PROC_NULL;
+	_mpi_group_null.size    = 0;
+
+	return (0);
+}
+
+/**
+ * @brief Finalizes the groups submodule.
+ *
+ * @returns Upon successful completion, zero is returned. A
+ * negative error code is returned instead.
+ */
+PUBLIC int mpi_group_finalize(void)
+{
+	/* Destructs the predefined groups. */
+	OBJ_DESTRUCT(&_mpi_group_null);
+
+	OBJ_DESTRUCT(&_mpi_group_empty);
+
+	return (0);
+}


### PR DESCRIPTION
# Description #
In this PR, we define the `MPI_Group` first draft. It defines a group of processes, and comes with functions for allocation, deallocation and initialization of the MPI predefined groups. Also, this PR defines a first draft of the `mpi.h` header file, describing some of its constants and definitions.

# Related Issues # 
- Closes #5 - [mpi] MPI_Groups