### PR TITLE
[mpi] MPI_Communicators

### DIFF
--- a/include/mpi.h
+++ b/include/mpi.h
@@ -162,15 +162,21 @@
  */
 extern struct mpi_group_t _mpi_group_empty;
 extern struct mpi_group_t _mpi_group_null;
+extern struct mpi_communicator_t _mpi_comm_world;
+extern struct mpi_communicator_t _mpi_comm_self;
+extern struct mpi_communicator_t _mpi_comm_null;
 
 /**
  * @brief Predefined handlers.
  */
 #define MPI_GROUP_EMPTY &_mpi_group_empty
+#define MPI_COMM_SELF   &_mpi_comm_self
+#define MPI_COMM_WORLD  &_mpi_comm_world
 
 /**
  * @brief Null handlers.
  */
-#define MPI_GROUP_NULL  &_mpi_group_null
+#define MPI_GROUP_NULL &_mpi_group_null
+#define MPI_COMM_NULL  &_mpi_comm_null
 
 #endif /* NANVIX_LIBMPI_H_ */

--- a/include/mpi/communicator.h
+++ b/include/mpi/communicator.h
@@ -1,0 +1,150 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_MPI_COMMUNICATOR_H_
+#define NANVIX_MPI_COMMUNICATOR_H_
+
+#include <nanvix/hal.h>
+#include <mputil/object.h>
+#include <mpi/group.h>
+#include <mpi.h>
+
+/**
+ * @brief Struct that defines a mpi_communicator.
+ *
+ * @todo Insert a MPI_Errorhandler reference when impl. supports it.
+ */
+struct mpi_communicator_t
+{
+	object_t super;                    /* Base object class.              */
+
+	struct mpi_group_t *group;         /* Group associated with the comm. */
+	int my_rank;                       /* Local rank inside comm.         */
+	int pt2pt_cid;                     /* Point-to-point context ID.      */
+	int coll_cid;                      /* Collective context ID.          */
+	struct mpi_communicator_t *parent; /* Parent communicator.            */
+};
+
+typedef struct mpi_communicator_t mpi_communicator_t;
+
+/* Class declaration. */
+OBJ_CLASS_DECLARATION(mpi_communicator_t);
+
+/**
+ * @brief Allocates a new communicator.
+ *
+ * @param group_size Communicator group size.
+ *
+ * @returns A pointer to the new allocated communicator.
+ */
+extern mpi_communicator_t * mpi_comm_allocate(int group_size);
+
+/**
+ * @brief Frees the specified communicator.
+ *
+ * @param comm Communicator to be freed.
+ *
+ * @returns Upon successful completion, zero is returned with
+ * @p comm pointing to NULL. A negative error code is returned
+ * instead, without modifications on @p comm.
+ */
+extern int mpi_comm_free(mpi_communicator_t **comm);
+
+/**
+ * @brief Gets the local process rank in @p comm.
+ *
+ * @param comm Target communicator.
+ *
+ * @returns The local process rank in the communicator.
+ */
+static inline int mpi_comm_rank(mpi_communicator_t * comm)
+{
+    return (comm->my_rank);
+}
+
+/**
+ * @brief Gets the size of the communicator.
+ *
+ * @param comm Target communicator.
+ *
+ * @returns The number of processes that participates in @p comm.
+ */
+static inline int mpi_comm_size(mpi_communicator_t * comm)
+{
+    return (comm->group->size);
+}
+
+/**
+ * @brief Gets the communicator point-to-point cid.
+ *
+ * @param comm Target communicator.
+ *
+ * @returns The communicator's point-to-point context ID.
+ */
+static inline int mpi_comm_get_pt2pt_cid(mpi_communicator_t* comm)
+{
+    return (comm->pt2pt_cid);
+}
+
+/**
+ * @brief Gets the communicator collective cid.
+ *
+ * @param comm Target communicator.
+ *
+ * @returns The communicator's collective context ID.
+ */
+static inline int mpi_comm_get_coll_cid(mpi_communicator_t* comm)
+{
+    return (comm->coll_cid);
+}
+
+/**
+ * @brief Extracts the group associated with the communicator.
+ *
+ * @param comm  The target communicator.
+ * @param group A group pointer to reference the target group upon success.
+ *
+ * @returns Upon successful completion, MPI_SUCCESS is returned with the
+ * group reference on @p group. An MPI_ERROR_CODE is returned instead with
+ * group pointing to NULL.
+ */
+extern int mpi_comm_group(mpi_communicator_t *comm, mpi_group_t **group);
+
+/**
+ * @brief Initializes the communicators submodule.
+ *
+ * @returns Upon successful completion, zero is returned. A
+ * negative error code is returned instead.
+ */
+extern int mpi_comm_init(void);
+
+/**
+ * @brief Finalizes the communicators submodule.
+ *
+ * @returns Upon successful completion, zero is returned. A
+ * negative error code is returned instead.
+ */
+extern int mpi_comm_finalize(void);
+
+#endif /* NANVIX_MPI_COMMUNICATOR_H_ */

--- a/include/mpi/group.h
+++ b/include/mpi/group.h
@@ -104,6 +104,30 @@ static inline int mpi_group_rank(mpi_group_t * group)
 }
 
 /**
+ * @brief Sets the local process rank inside the given group.
+ *
+ * @param group Group descriptor.
+ * @param proc  Local process descriptor.
+ *
+ * @note A NULL pointer in @p proc will set the group rank to MPI_UNDEFINED.
+ */
+extern void mpi_group_set_rank(mpi_group_t * group, mpi_process_t * proc);
+
+/**
+ * @brief Increments the refcount of each process in @p group.
+ *
+ * @param group Group of processes to be manipulated.
+ */
+extern void mpi_group_increment_proc_count(mpi_group_t *);
+
+/**
+ * @brief Decrements the refcount of each process in @p group.
+ *
+ * @param group Group of processes to be manipulated.
+ */
+extern void mpi_group_decrement_proc_count(mpi_group_t *);
+
+/**
  * @brief Initializes the groups submodule.
  *
  * @returns Upon successful completion, zero is returned. A

--- a/include/mputil/proc.h
+++ b/include/mputil/proc.h
@@ -28,6 +28,8 @@
 #include <nanvix/hal.h>
 #include <mputil/object.h>
 
+#define PROCESS_NAME_MAX_LENGTH 32
+
 /**
  * @brief Struct that defines a dynamic pointer array.
  */
@@ -35,6 +37,7 @@ struct mpi_process_t
 {
 	object_t super; /* Base object class. */
 
+	char name[PROCESS_NAME_MAX_LENGTH];
 	int pid;        /* Process ID.        */
 	int nodenum;    /* Process nodenum.   */
 };
@@ -73,6 +76,26 @@ static inline int process_nodenum(mpi_process_t *proc)
  * @returns Pointer to the local process descriptor.
  */
 extern mpi_process_t * process_local(void);
+
+/**
+ * @brief Make a name lookup on the processes list.
+ *
+ * @param name Name of process to lookup.
+ *
+ * @returns UPon successful completion. a pointer to the process
+ * descriptor is returned. Upon failure, a NULL pointer is returned
+ * instead.
+ *
+ * @note If the name could not be found, a NULL pointer is returned.
+ */
+extern mpi_process_t * process_lookup(const char* name);
+
+/**
+ * @brief Gets the number of processes active.
+ *
+ * @returns The number of active processes.
+ */
+extern int mpi_proc_count(void);
 
 /**
  * @brief Initializes the processes submodule.

--- a/src/mpi/communicator/communicator.c
+++ b/src/mpi/communicator/communicator.c
@@ -1,0 +1,226 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/hlib.h>
+#include <nanvix/ulib.h>
+#include <posix/errno.h>
+#include <mpi/communicator.h>
+
+PRIVATE void mpi_comm_construct(mpi_communicator_t *);
+PRIVATE void mpi_comm_destruct(mpi_communicator_t *);
+
+OBJ_CLASS_INSTANCE(mpi_communicator_t, &mpi_comm_construct, &mpi_comm_destruct,
+	               sizeof(mpi_communicator_t));
+
+/**
+ * @brief Predefined communicators.
+ */
+mpi_communicator_t _mpi_comm_world;
+mpi_communicator_t _mpi_comm_self;
+mpi_communicator_t _mpi_comm_null;
+
+/**
+ * @brief Communicator constructor.
+ */
+PRIVATE void mpi_comm_construct(mpi_communicator_t * comm)
+{
+	uassert(comm != NULL);
+
+	comm->group     = NULL;
+	comm->my_rank   = MPI_UNDEFINED;
+	comm->pt2pt_cid = MPI_UNDEFINED;
+	comm->coll_cid  = MPI_UNDEFINED;
+	comm->parent    = NULL;
+}
+
+/**
+ * @brief Communicator destructor.
+ *
+ * @note When cid allocation became dynamic, it should be released here.
+ */
+PRIVATE void mpi_comm_destruct(mpi_communicator_t * comm)
+{
+    uassert(comm != NULL);
+
+    /* Release the associated group. */
+    if (comm->group != NULL)
+    	OBJ_RELEASE(comm->group);
+
+    /* Release parent reference. */
+    if (comm->parent != NULL)
+    	OBJ_RELEASE(comm->parent);
+}
+
+/**
+ * @see mpi_comm_allocate() at communicator.h.
+ */
+PUBLIC mpi_communicator_t * mpi_comm_allocate(int group_size)
+{
+	mpi_communicator_t *new_comm;
+	mpi_group_t *group;
+
+	/* Bad group_size. */
+	if (group_size < 0)
+		return (NULL);
+
+	/* Allocates a new communicator. */
+	new_comm = OBJ_NEW(mpi_communicator_t);
+	if (new_comm == NULL)
+		return (NULL);
+
+	/* Allocates a new group. */
+	group = mpi_group_allocate(group_size);
+	if (group == NULL)
+	{
+		OBJ_RELEASE(new_comm);
+		return (NULL);
+	}
+
+	new_comm->group = group;
+
+	return (new_comm);
+}
+
+/**
+ * @see mpi_comm_free() at communicator.h.
+ */
+PUBLIC int mpi_comm_free(mpi_communicator_t **comm)
+{
+	/* Bad communicator. */
+	if (*comm == NULL)
+		return (-EINVAL);
+
+	OBJ_RELEASE(comm);
+	*comm = MPI_COMM_NULL;
+
+	return (0);
+}
+
+/**
+ * @see mpi_comm_group() at communicator.h.
+ */
+PUBLIC int mpi_comm_group(mpi_communicator_t *comm, mpi_group_t **group)
+{
+	/* Bad communicator. */
+	if (comm == NULL)
+		return (-EINVAL);
+
+	/* Bad group receptor. */
+	if (group == NULL)
+		return (-EINVAL);
+
+	/* Increments the group reference counter. */
+	OBJ_RETAIN(comm->group);
+	*group = comm->group;
+
+	return (0);
+}
+
+/**
+ * @see mpi_comm_init() at communicator.h.
+ *
+ * @todo See necessity of defining a communicators array.
+ * @todo See necessity of freeing pre-allocated comms in case of failure.
+ */
+PUBLIC int mpi_comm_init(void)
+{
+	mpi_group_t *group;
+	size_t size;
+	char name[PROCESS_NAME_MAX_LENGTH];
+
+	/* Gets the number of active processes. */
+	size = mpi_proc_count();
+
+	/* Setup MPI_COMM_WORLD. */
+	OBJ_CONSTRUCT(&_mpi_comm_world, mpi_communicator_t);
+	group = OBJ_NEW(mpi_group_t);
+
+	group->procs = (mpi_process_t **) umalloc(size * sizeof(mpi_process_t *));
+	if (group->procs == NULL)
+		return (-ENOMEM);
+
+	group->size = size;
+
+	for (unsigned int i = 0; i < size; ++i)
+	{
+		usprintf(name, "nanvix-process-%d", i);
+		group->procs[i] = process_lookup(name);
+
+		uassert(group->procs[i] != NULL);
+	}
+
+	mpi_group_increment_proc_count(group);
+	mpi_group_set_rank(group, process_local());
+
+	_mpi_comm_world.group     = group;
+	_mpi_comm_world.my_rank   = group->my_rank;
+	_mpi_comm_world.pt2pt_cid = 0;
+	_mpi_comm_world.coll_cid  = 1;
+
+	/* Setup MPI_COMM_SELF. */
+	OBJ_CONSTRUCT(&_mpi_comm_self, mpi_communicator_t);
+	group = OBJ_NEW(mpi_group_t);
+
+	group->procs = (mpi_process_t **) umalloc(sizeof(mpi_process_t *));
+	if (group->procs == NULL)
+		return (-ENOMEM);
+
+	group->size = 1;
+	group->procs[0] = process_local();
+
+	mpi_group_increment_proc_count(group);
+	mpi_group_set_rank(group, process_local());
+
+	_mpi_comm_self.group     = group;
+	_mpi_comm_self.my_rank   = group->my_rank;
+	_mpi_comm_self.pt2pt_cid = 2;
+	_mpi_comm_self.coll_cid  = MPI_UNDEFINED;
+
+	/* Setup MPI_COMM_NULL. */
+	OBJ_CONSTRUCT(&_mpi_comm_null, mpi_communicator_t);
+	_mpi_comm_null.group     = MPI_GROUP_NULL;
+	_mpi_comm_null.my_rank   = MPI_PROC_NULL;
+	OBJ_RETAIN(MPI_GROUP_NULL);
+	
+	return (0);
+}
+
+/**
+ * @see mpi_comm_finalize() at communicator.h.
+ *
+ * @todo If define a communicators list we should free it here.
+ */
+PUBLIC int mpi_comm_finalize(void)
+{
+	/* Destruct MPI_COMM_SELF. */
+	OBJ_DESTRUCT(&_mpi_comm_self);
+
+	/* Destruct MPI_COMM_WORLD. */
+	OBJ_DESTRUCT(&_mpi_comm_world);
+
+	/* Destruct MPI_COMM_NULL. */
+	OBJ_DESTRUCT(&_mpi_comm_null);
+
+	return (0);
+}

--- a/src/mpi/group/group.c
+++ b/src/mpi/group/group.c
@@ -29,8 +29,6 @@
 
 PRIVATE void mpi_group_construct(mpi_group_t *);
 PRIVATE void mpi_group_destruct(mpi_group_t *);
-PRIVATE void mpi_group_increment_proc_count(mpi_group_t *);
-PRIVATE void mpi_group_decrement_proc_count(mpi_group_t *);
 
 OBJ_CLASS_INSTANCE(mpi_group_t, &mpi_group_construct, &mpi_group_destruct, sizeof(mpi_group_t));
 
@@ -56,7 +54,7 @@ PRIVATE void mpi_group_construct(mpi_group_t * group)
 /**
  * @brief Group destructor.
  */
-PRIVATE void mpi_group_destruct(mpi_group_t * group)
+PUBLIC void mpi_group_destruct(mpi_group_t * group)
 {
     uassert(group != NULL);
 
@@ -75,7 +73,7 @@ PRIVATE void mpi_group_destruct(mpi_group_t * group)
  *
  * @param group Group of processes to be manipulated.
  */
-PRIVATE void mpi_group_increment_proc_count(mpi_group_t * group)
+PUBLIC void mpi_group_increment_proc_count(mpi_group_t * group)
 {
 	uassert(group != NULL);
 	uassert(group->size >= 0);
@@ -93,7 +91,7 @@ PRIVATE void mpi_group_increment_proc_count(mpi_group_t * group)
  *
  * @param group Group of processes to be manipulated.
  */
-PRIVATE void mpi_group_decrement_proc_count(mpi_group_t * group)
+PUBLIC void mpi_group_decrement_proc_count(mpi_group_t * group)
 {
 	uassert(group != NULL);
 	uassert(group->size >= 0);
@@ -203,6 +201,34 @@ PUBLIC int mpi_group_free(mpi_group_t ** group)
 	*group = MPI_GROUP_NULL;
 
 	return (0);
+}
+
+/**
+ * @brief Sets the local process rank inside the given group.
+ *
+ * @param group Group descriptor.
+ * @param proc  Local process descriptor.
+ *
+ * @note A NULL pointer in @p proc will set the group rank to MPI_UNDEFINED.
+ */
+PUBLIC void mpi_group_set_rank(mpi_group_t * group, mpi_process_t * proc)
+{
+	uassert(group != NULL);
+
+	group->my_rank = MPI_UNDEFINED;
+
+	/* Loop over the group to assert that proc participates on it. */
+	if (proc != NULL)
+	{
+		for (int i = 0; i < group->size; ++i)
+		{
+			if (proc == group->procs[i])
+			{
+				group->my_rank = i;
+				break;
+			}
+		}
+	}
 }
 
 /**

--- a/src/mpi/group/group.c
+++ b/src/mpi/group/group.c
@@ -54,7 +54,7 @@ PRIVATE void mpi_group_construct(mpi_group_t * group)
 /**
  * @brief Group destructor.
  */
-PUBLIC void mpi_group_destruct(mpi_group_t * group)
+PRIVATE void mpi_group_destruct(mpi_group_t * group)
 {
     uassert(group != NULL);
 

--- a/src/mpi/makefile
+++ b/src/mpi/makefile
@@ -49,7 +49,8 @@ LIBS += $(LIBDIR)/$(BARELIB) $(THEIR_LIBS)
 #===============================================================================
 
 # C Source Files
-SRC = $(wildcard group/*.c)
+SRC = $(wildcard group/*.c) \
+      $(wildcard communicator/*.c)
 
 #===============================================================================
 # Object Files

--- a/src/mputil/proc.c
+++ b/src/mputil/proc.c
@@ -58,6 +58,7 @@ PRIVATE void process_construct(mpi_process_t *proc)
 	uassert(proc != NULL);
 
     proc->nodenum = -1;
+    proc->pid     = -1;
 }
 
 /**
@@ -102,6 +103,7 @@ PUBLIC int process_allocate(int nodeid)
 	/* Initializes the process info. */
 	proc->pid     = ret;
 	proc->nodenum = nodeid;
+	usprintf(proc->name, "nanvix-process-%d", nodeid);
 
 	return (ret);
 }
@@ -114,6 +116,47 @@ PUBLIC int process_allocate(int nodeid)
 PUBLIC mpi_process_t * process_local(void)
 {
 	return (_local_proc);
+}
+
+/**
+ * @brief Make a name lookup on the processes list.
+ *
+ * @param name Name of process to lookup.
+ *
+ * @returns Upon successful completion. a pointer to the process
+ * descriptor is returned. Upon failure, a NULL pointer is returned
+ * instead.
+ *
+ * @note If the name could not be found, a NULL pointer is returned.
+ */
+PUBLIC mpi_process_t * process_lookup(const char* name)
+{
+	int limit;
+	mpi_process_t * proc;
+
+	limit = pointer_array_get_max_size(&_processes_list);
+
+	for (int i = 0; i < limit; ++i)
+	{
+		proc = (mpi_process_t *) pointer_array_get_item(&_processes_list, i);
+		if (proc == NULL)
+			continue;
+
+		if (!ustrcmp(name, proc->name))
+			return (proc);
+	}
+
+	return (NULL);
+}
+
+/**
+ * @brief Gets the number of processes active.
+ *
+ * @returns The number of active processes.
+ */
+PUBLIC int mpi_proc_count(void)
+{
+	return (_processes_nr);
 }
 
 /**

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -27,6 +27,7 @@
 #include <mputil/proc.h>
 #include <mputil/object.h>
 #include <mpi/group.h>
+#include <mpi/communicator.h>
 #include <mpi.h>
 
 /**
@@ -57,6 +58,14 @@ int __main2(int argc, const char *argv[])
 
 	group = mpi_group_allocate(2);
 
+	uassert(mpi_group_rank(group) == MPI_UNDEFINED);
+
+	mpi_group_set_rank(group, process_lookup("nanvix-process-0"));
+
+	uassert(mpi_group_rank(group) == MPI_UNDEFINED);
+
+	uprintf("Set Rank asserted");
+
 	uassert(group != MPI_GROUP_EMPTY);
 
 	uprintf("Group asserted");
@@ -75,9 +84,23 @@ int __main2(int argc, const char *argv[])
 
 	mpi_group_free(&group);
 
+	mpi_comm_init();
+
+	uprintf("Communicators initialized");
+
+	mpi_comm_finalize();
+
+	uprintf("Communicators finalized");
+
 	uassert(mpi_group_finalize() == 0);
 
 	uprintf("Group system finalized");
+
+	local = process_lookup("nanvix-process-0");
+
+	uassert(local == process_local());
+
+	uprintf("Asserted lookup");
 
 	uassert(mpi_proc_finalize() == 0);
 


### PR DESCRIPTION
# Description #
In this PR we define the `MPI_Communicator` first draft. It defines a group of communication, based on a set of processes that participates on it and defines an universe of communication. Also, some small enhancements were made to the `Process` and `MPI_Group` interfaces, to provide the communicators support.

# Related Issues #
- Closes #8 - [mpi] MPI_Communicators