### PR TITLE
[mpi] MPI_Errhandlers

### DIFF
--- a/include/mpi.h
+++ b/include/mpi.h
@@ -26,6 +26,30 @@
 #define NANVIX_LIBMPI_MPI_H_
 
 /**
+ * @note Temporary definitions. Declared only for convenience on errhandlers definition.
+ * It should be dropped from here and defined in specific files for each when properly
+ * supported.
+ */
+typedef struct mpi_win_t mpi_win_t;
+typedef struct mpi_file_t mpi_file_t;
+
+/**
+ * @brief User exported typedefs.
+ */
+typedef struct mpi_communicator_t *MPI_Comm;
+typedef struct mpi_group_t        *MPI_Group;
+typedef struct mpi_win_t          *MPI_Win;
+typedef struct mpi_file_t         *MPI_File;
+typedef struct mpi_errhandler_t   *MPI_Errhandler;
+
+/**
+ * @brief User exported function typedefs.
+ */
+typedef void MPI_Comm_errhandler_function(MPI_Comm *, int *, ...);
+typedef void MPI_Win_errhandler_function(MPI_Win *, int *, ...);
+typedef void MPI_File_errhandler_function(MPI_File *, int *, ...);
+
+/**
  * @brief Maximum string sizes constants.
  */
 #define MPI_MAX_DATAREP_STRING          64
@@ -165,18 +189,26 @@ extern struct mpi_group_t _mpi_group_null;
 extern struct mpi_communicator_t _mpi_comm_world;
 extern struct mpi_communicator_t _mpi_comm_self;
 extern struct mpi_communicator_t _mpi_comm_null;
+extern struct mpi_errhandler_t _mpi_errhandler_errors_fatal;
+extern struct mpi_errhandler_t _mpi_errhandler_errors_abort;
+extern struct mpi_errhandler_t _mpi_errors_return;
+extern struct mpi_errhandler_t _mpi_errhandler_null;
 
 /**
  * @brief Predefined handlers.
  */
-#define MPI_GROUP_EMPTY &_mpi_group_empty
-#define MPI_COMM_SELF   &_mpi_comm_self
-#define MPI_COMM_WORLD  &_mpi_comm_world
+#define MPI_GROUP_EMPTY      &_mpi_group_empty
+#define MPI_COMM_SELF        &_mpi_comm_self
+#define MPI_COMM_WORLD       &_mpi_comm_world
+#define MPI_ERRORS_ARE_FATAL &_mpi_errhandler_errors_fatal
+#define MPI_ERRORS_ABORT     &_mpi_errhandler_errors_abort
+#define MPI_ERRORS_RETURN    &_mpi_errors_return;
 
 /**
  * @brief Null handlers.
  */
-#define MPI_GROUP_NULL &_mpi_group_null
-#define MPI_COMM_NULL  &_mpi_comm_null
+#define MPI_GROUP_NULL      &_mpi_group_null
+#define MPI_COMM_NULL       &_mpi_comm_null
+#define MPI_ERRHANDLER_NULL &_mpi_errhandler_null;
 
 #endif /* NANVIX_LIBMPI_H_ */

--- a/include/mpi/communicator.h
+++ b/include/mpi/communicator.h
@@ -25,25 +25,27 @@
 #ifndef NANVIX_MPI_COMMUNICATOR_H_
 #define NANVIX_MPI_COMMUNICATOR_H_
 
-#include <nanvix/hal.h>
 #include <mputil/object.h>
 #include <mpi/group.h>
+#include <mpi/errhandler.h>
 #include <mpi.h>
 
 /**
  * @brief Struct that defines a mpi_communicator.
- *
- * @todo Insert a MPI_Errorhandler reference when impl. supports it.
  */
 struct mpi_communicator_t
 {
-	object_t super;                    /* Base object class.              */
+	object_t super;                        /* Base object class.             */
 
-	struct mpi_group_t *group;         /* Group associated with the comm. */
-	int my_rank;                       /* Local rank inside comm.         */
-	int pt2pt_cid;                     /* Point-to-point context ID.      */
-	int coll_cid;                      /* Collective context ID.          */
-	struct mpi_communicator_t *parent; /* Parent communicator.            */
+	struct mpi_group_t *group;             /* Group associated with comm.    */
+	int my_rank;                           /* Local rank inside comm.        */
+	int pt2pt_cid;                         /* Point-to-point context ID.     */
+	int coll_cid;                          /* Collective context ID.         */
+
+	mpi_errhandler_t *error_handler;       /* Comm error handler.            */
+	mpi_errhandler_type_t errhandler_type; /* Type of associated errhandler. */
+
+	struct mpi_communicator_t *parent;     /* Parent communicator.           */
 };
 
 typedef struct mpi_communicator_t mpi_communicator_t;

--- a/include/mpi/errhandler.h
+++ b/include/mpi/errhandler.h
@@ -1,0 +1,173 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_MPI_ERRHANDLER_H_
+#define NANVIX_MPI_ERRHANDLER_H_
+
+#include <mputil/object.h>
+#include <mpi/mpiruntime.h>
+#include <mpi/errhandler_predefined.h>
+#include <mpi.h>
+
+/**
+ * @brief Enum to describe the type of object that the error handler is defined.
+ */
+enum mpi_errhandler_type_t {
+    MPI_ERRHANDLER_TYPE_PREDEFINED,
+    MPI_ERRHANDLER_TYPE_COMM,
+    MPI_ERRHANDLER_TYPE_WIN,
+    MPI_ERRHANDLER_TYPE_FILE
+};
+typedef enum mpi_errhandler_type_t mpi_errhandler_type_t;
+
+/**
+ * @brief Struct that defines a mpi_errhandler.
+ */
+struct mpi_errhandler_t
+{
+	object_t super; /* Base object class. */
+
+	mpi_errhandler_type_t errhandler_object_type;  /* Errhandler defined for... */
+	MPI_Comm_errhandler_function *comm_handler_fn; /* Comm_errhandler function. */
+	MPI_Win_errhandler_function *win_handler_fn;   /* File_errhandler function. */
+	MPI_File_errhandler_function *file_handler_fn; /* Win_errhandler function.  */
+};
+
+typedef struct mpi_errhandler_t mpi_errhandler_t;
+
+/* Class declaration. */
+OBJ_CLASS_DECLARATION(mpi_errhandler_t);
+
+/**
+ * @brief Checks the current state of MPI environment and calls an error
+ * handler if not valid (not initialized or already finished).
+ *
+ * @param name Name of the erroneus function.
+ *
+ * @note Calls MPI_ERRORS_ARE_FATAL handler directly because MPI_Comm_World doesn't
+ * exist (not initialized before MPI_Init or already destroyed after MPI_Finalize).
+ */
+#define MPI_CHECK_INIT_FINALIZE(name)				             \
+	{		                                                     \
+		int state = _mpi_state;		                             \
+		if ((state < OMPI_MPI_STATE_INITIALIZED) ||	             \
+		    (state >= OMPI_MPI_STATE_FINALIZE_STARTED)) {	     \
+			mpi_errors_are_fatal_comm_handler(NULL, NULL, name); \
+		}	                                                     \
+	}
+
+/**
+ * @brief Invokes an object error handler.
+ *
+ * @param mpi_object The MPI object to invoke the errhandler.
+ * @param errcode    The error code to be returned.
+ * @param message    Aditional error message.
+ */
+#define MPI_ERRHANDLER_INVOKE(mpi_object, errcode, message)	      \
+	mpi_errhandler_invoke(mpi_object->error_handler,              \
+	                      mpi_object,                             \
+	                      (int)(mpi_object->errhandler_type),     \
+	                      errcode, message                        \
+	);
+
+/**
+ * @brief Conditionally invokes an MPI error handler.
+ *
+ * @param rc         The return code to be checked.
+ * @param mpi_object The MPI object to invoke the errhandler.
+ * @param errcode    The error code to be returned.
+ * @param message    Aditional error message.
+ *
+ * @note This macro will invoke the error handler if the return
+ * code is not MPI_SUCCESS, and return @p errorcode.
+ */
+#define MPI_ERRHANDLER_CHECK(rc, mpi_object, errcode, message) 			\
+	if (rc != MPI_SUCCESS) {                                        	\
+		mpi_errhandler_invoke(mpi_object->error_handler,                \
+		                      mpi_object,                               \
+		                      (int)mpi_object->errhandler_type,         \
+		                      errcode, message                          \
+		);                                                              \
+		return (errcode);                                               \
+	}
+
+/**
+ * @brief Conditionally invokes an MPI error handler.
+ *
+ * @param rc         The return code to be checked.
+ * @param mpi_object The MPI object to invoke the errhandler.
+ * @param errcode    The error code to be returned.
+ * @param message    Aditional error message.
+ *
+ * @note This macro will invoke the error handler if the return
+ * code is not MPI_SUCCESS.
+ *
+ * @returns Upon successful completion, MPI_SUCCESS is returned. If
+ * the error handler was invoked, @p errorcode is returned.
+ */
+#define OMPI_ERRHANDLER_RETURN(rc, mpi_object, err_code, message)		\
+	if (rc != MPI_SUCCESS) {	                                        \
+		mpi_errhandler_invoke(mpi_object->error_handler,                \
+		                      mpi_object,                               \
+		                      (int)mpi_object->errhandler_type,         \
+		                      errcode, message                          \
+		);                                                              \
+		return (errcode);                                               \
+	} else {	                                                        \
+		return MPI_SUCCESS;                                             \
+	}
+
+/**
+ * @brief Invokes an object error handler.
+ *
+ * @param errhandler The error handler to invoke.
+ * @param mpi_object The object to invoke the errhandler.
+ * @param type       The type of @p mpi_object.
+ * @param errcode    The error code associated to the call.
+ * @param message    Additional error message.
+ *
+ * @returns @p errcode.
+ *
+ * @note This function should be called from one of the macros given above.
+ */
+extern int mpi_errhandler_invoke(mpi_errhandler_t *errhandler, void *mpi_object,
+                                 int type, int errcode, const char *message);
+
+/**
+ * @brief Initializes the error handling submodule.
+ *
+ * @returns Upon successful completion, zero is returned. A
+ * negative error code is returned instead.
+ */
+extern int mpi_errhandler_init(void);
+
+/**
+ * @brief Finalizes the error handling submodule.
+ *
+ * @returns Upon successful completion, zero is returned. A
+ * negative error code is returned instead.
+ */
+extern int mpi_errhandler_finalize(void);
+
+#endif /* NANVIX_MPI_ERRHANDLER_H_ */

--- a/include/mpi/errhandler_predefined.h
+++ b/include/mpi/errhandler_predefined.h
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_MPI_ERRHANDLER_PREDEFINED_H_
+#define NANVIX_MPI_ERRHANDLER_PREDEFINED_H_
+
+#include <mpi.h>
+
+/**
+ * @note Forward declaration to avoid circular references.
+ */
+struct mpi_communicator_t;
+
+/**
+ * @brief Handler functions for MPI_ERRORS_ARE_FATAL.
+ */
+extern void mpi_errors_are_fatal_comm_handler(struct mpi_communicator_t **comm,
+                                              int *errcode, ...);
+extern void mpi_errors_are_fatal_file_handler(mpi_file_t **file,
+                                              int *errcode, ...);
+extern void mpi_errors_are_fatal_win_handler(mpi_win_t **win,
+                                             int *errcode, ...);
+
+/**
+ * @brief Handler functions for MPI_ERRORS_ABORT.
+ */
+extern void mpi_errors_abort_comm_handler(struct mpi_communicator_t **comm,
+                                          int *errcode, ...);
+extern void mpi_errors_abort_file_handler(mpi_file_t **file,
+                                          int *errcode, ...);
+extern void mpi_errors_abort_win_handler(mpi_win_t **win,
+                                         int *errcode, ...);
+
+/**
+ * @brief Handler functions for MPI_ERRORS_RETURN.
+ */
+extern void mpi_errors_return_comm_handler(struct mpi_communicator_t **comm,
+                                           int *errcode, ...);
+extern void mpi_errors_return_file_handler(mpi_file_t **file,
+                                           int *errcode, ...);
+extern void mpi_errors_return_win_handler(mpi_win_t **win,
+                                          int *errcode, ...);
+
+#endif /* NANVIX_MPI_ERRHANDLER_PREDEFINED_H_ */

--- a/include/mpi/group.h
+++ b/include/mpi/group.h
@@ -25,7 +25,6 @@
 #ifndef NANVIX_MPI_GROUP_H_
 #define NANVIX_MPI_GROUP_H_
 
-#include <nanvix/hal.h>
 #include <mputil/object.h>
 #include <mputil/proc.h>
 #include <mpi.h>

--- a/include/mpi/mpiruntime.h
+++ b/include/mpi/mpiruntime.h
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_MPI_RUNTIME_H_
+#define NANVIX_MPI_RUNTIME_H_
+
+#include <mpi.h>
+
+/**
+ * @note Forward struct declaration to avoid circular references.
+ */
+struct mpi_communicator_t;
+
+/**
+ * @brief MPI runtime possible states enum.
+ */
+typedef enum {
+	MPI_STATE_NOT_INITIALIZED = 0,
+	MPI_STATE_INIT_STARTED,
+	MPI_STATE_INITIALIZED,
+	MPI_STATE_FINALIZE_STARTED,
+	MPI_STATE_FINALIZED
+} mpi_state_t;
+
+/**
+ * @brief Global MPI state variable.
+ */
+extern mpi_state_t _mpi_state;
+
+/**
+ * @brief Initializes the MPI runtime.
+ *
+ * @returns Upon successful completion, MPI_SUCCESS is returned. A
+ * negative error code is returned instead.
+ */
+extern int mpi_init(void);
+
+/**
+ * @brief Finalizes the MPI runtime.
+ *
+ * @returns Upon successful completion, MPI_SUCCESS is returned. A
+ * negative error code is returned instead.
+ */
+extern int mpi_finalize(void);
+
+/**
+ * @brief Aborts the MPI runtime.
+ *
+ * @param comm     Communicator that have the group of processes to be aborted.
+ * @param errocode Errorcode to be returned to the caller environment.
+ *
+ * @returns Upon successful completion, MPI_SUCCESS is returned. A
+ * negative error code is returned instead.
+ */
+extern int mpi_abort(struct mpi_communicator_t *comm, int errorcode);
+
+#endif /* NANVIX_MPI_RUNTIME_H_ */

--- a/src/mpi/errhandler/errhandler.c
+++ b/src/mpi/errhandler/errhandler.c
@@ -26,6 +26,7 @@
 #include <nanvix/ulib.h>
 #include <posix/errno.h>
 #include <mpi/errhandler.h>
+#include <mpi/communicator.h>
 
 PRIVATE void mpi_errhandler_construct(mpi_errhandler_t *);
 PRIVATE void mpi_errhandler_destruct(mpi_errhandler_t *);

--- a/src/mpi/errhandler/errhandler.c
+++ b/src/mpi/errhandler/errhandler.c
@@ -1,0 +1,155 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/hlib.h>
+#include <nanvix/ulib.h>
+#include <posix/errno.h>
+#include <mpi/errhandler.h>
+
+PRIVATE void mpi_errhandler_construct(mpi_errhandler_t *);
+PRIVATE void mpi_errhandler_destruct(mpi_errhandler_t *);
+
+OBJ_CLASS_INSTANCE(mpi_errhandler_t, &mpi_errhandler_construct,
+                   &mpi_errhandler_destruct, sizeof(mpi_errhandler_t));
+
+/**
+ * @brief Predefined error handlers.
+ */
+mpi_errhandler_t _mpi_errhandler_null;
+mpi_errhandler_t _mpi_errhandler_errors_fatal;
+mpi_errhandler_t _mpi_errhandler_errors_abort;
+mpi_errhandler_t _mpi_errors_return;
+
+/**
+ * @brief Error handler constructor.
+ */
+PRIVATE void mpi_errhandler_construct(mpi_errhandler_t * errhandler)
+{
+	uassert(errhandler != NULL);
+
+	errhandler->comm_handler_fn = NULL;
+	errhandler->win_handler_fn  = NULL;
+	errhandler->file_handler_fn = NULL;
+}
+
+/**
+ * @brief Error handler destructor.
+ */
+PRIVATE void mpi_errhandler_destruct(mpi_errhandler_t * errhandler)
+{
+	uassert(errhandler != NULL);
+}
+
+/**
+ * @see mpi_errhandler_invoke() at errhandler.h.
+ */
+PUBLIC int mpi_errhandler_invoke(mpi_errhandler_t *errhandler, void *mpi_object,
+                                 int type, int errcode, const char *message)
+{
+	mpi_communicator_t *comm;
+	mpi_win_t *win;
+	mpi_file_t *file;
+
+	/* Invalid errhandler. Abort all connected processes. */
+	if (errhandler == NULL) {
+		mpi_errors_are_fatal_comm_handler(NULL, NULL, message);
+		return errcode;
+	}
+
+	/* Select handler function based on @p type. */
+	switch (type)
+	{
+		case MPI_ERRHANDLER_TYPE_COMM:
+			comm = (mpi_communicator_t *) mpi_object;
+			errhandler->comm_handler_fn(&comm, &errcode, message, NULL);
+			break;
+
+		case MPI_ERRHANDLER_TYPE_WIN:
+			win = (mpi_win_t *) mpi_object;
+			errhandler->win_handler_fn(&win, &errcode, message, NULL);
+			break;
+
+		case MPI_ERRHANDLER_TYPE_FILE:
+			file = (mpi_file_t *) mpi_object;
+			errhandler->file_handler_fn(&file, &errcode, message, NULL);
+			break;
+
+		default:
+			/* UNREACHABLE */
+			upanic("Unrecognized Errhandler type.");
+			break;
+	}
+
+	return errcode;
+}
+
+/**
+ * @see mpi_errhandler_init() at errhandler.h.
+ */
+PUBLIC int mpi_errhandler_init(void)
+{
+	/* MPI_ERRHANDLER_ERRORS_ARE_FATAL. */
+	OBJ_CONSTRUCT(&_mpi_errhandler_errors_fatal, mpi_errhandler_t);
+	_mpi_errhandler_errors_fatal.errhandler_object_type = MPI_ERRHANDLER_TYPE_PREDEFINED;
+	_mpi_errhandler_errors_fatal.comm_handler_fn        = &mpi_errors_are_fatal_comm_handler;
+	_mpi_errhandler_errors_fatal.win_handler_fn         = &mpi_errors_are_fatal_win_handler;
+	_mpi_errhandler_errors_fatal.file_handler_fn        = &mpi_errors_are_fatal_file_handler;
+
+	/* MPI_ERRHANDLER_ERRORS_ABORT. */
+	OBJ_CONSTRUCT(&_mpi_errhandler_errors_abort, mpi_errhandler_t);
+	_mpi_errhandler_errors_abort.errhandler_object_type = MPI_ERRHANDLER_TYPE_PREDEFINED;
+	_mpi_errhandler_errors_abort.comm_handler_fn        = &mpi_errors_abort_comm_handler;
+	_mpi_errhandler_errors_abort.win_handler_fn         = &mpi_errors_abort_win_handler;
+	_mpi_errhandler_errors_abort.file_handler_fn        = &mpi_errors_abort_file_handler;
+
+	/* MPI_ERRHANDLER_ERRORS_RETURN. */
+	OBJ_CONSTRUCT(&_mpi_errors_return, mpi_errhandler_t);
+	_mpi_errors_return.errhandler_object_type = MPI_ERRHANDLER_TYPE_PREDEFINED;
+	_mpi_errors_return.comm_handler_fn        = &mpi_errors_return_comm_handler;
+	_mpi_errors_return.win_handler_fn         = &mpi_errors_return_win_handler;
+	_mpi_errors_return.file_handler_fn        = &mpi_errors_return_file_handler;
+
+	/* MPI_ERRHANDLER_NULL. */
+	OBJ_CONSTRUCT(&_mpi_errhandler_null, mpi_errhandler_t);
+	_mpi_errhandler_null.errhandler_object_type = MPI_ERRHANDLER_TYPE_PREDEFINED;
+	_mpi_errhandler_null.comm_handler_fn        = NULL;
+	_mpi_errhandler_null.win_handler_fn         = NULL;
+	_mpi_errhandler_null.file_handler_fn        = NULL;
+
+	return (MPI_SUCCESS);
+}
+
+/**
+ * @see mpi_errhandler_finalize() at errhandler.h.
+ */
+PUBLIC int mpi_errhandler_finalize(void)
+{
+	/* Destructs the predefined error handlers. */
+	OBJ_DESTRUCT(&_mpi_errhandler_null);
+	OBJ_DESTRUCT(&_mpi_errhandler_errors_fatal);
+	OBJ_DESTRUCT(&_mpi_errhandler_errors_abort);
+	OBJ_DESTRUCT(&_mpi_errors_return);
+
+	return (MPI_SUCCESS);
+}

--- a/src/mpi/errhandler/errhandler_predefined.c
+++ b/src/mpi/errhandler/errhandler_predefined.c
@@ -1,0 +1,222 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/hlib.h>
+#include <nanvix/ulib.h>
+#include <posix/errno.h>
+#include <mpi/errhandler_predefined.h>
+#include <mpi/communicator.h>
+#include <mpi/mpiruntime.h>
+
+static void print_error_message(int *errcode, va_list arglist);
+static void backend_abort(mpi_communicator_t *comm, int *errcode, va_list arglist);
+
+/*============================================================================*
+ * MPI_ERRORS_ARE_FATAL                                                       *
+ *============================================================================*/
+
+PUBLIC void mpi_errors_are_fatal_comm_handler(mpi_communicator_t **comm,
+                                              int *errcode, ...)
+{
+	int state;
+	va_list arglist;
+
+	UNUSED(comm);
+
+	state = _mpi_state;
+
+	va_start(arglist, errcode);
+
+	/* Error occured within MPI_Init and MPI_Finalize? */
+	if (state >= MPI_STATE_INITIALIZED && state < MPI_STATE_FINALIZE_STARTED)
+	{
+		/* Aborts all connected processes. */
+		backend_abort(&_mpi_comm_world, errcode, arglist);
+	}
+	else
+	{
+		/* Error occured before Init / after Finalize. Abort only locally. */
+		backend_abort(&_mpi_comm_self, errcode, arglist);
+	}
+}
+
+PUBLIC void mpi_errors_are_fatal_file_handler(mpi_file_t **file,
+                                              int *errcode, ...)
+{
+	UNUSED(file);
+	UNUSED(errcode);
+
+	uprintf("File handlers not supported yet.");
+}
+
+PUBLIC void mpi_errors_are_fatal_win_handler(mpi_win_t **win,
+                                             int *errcode, ...)
+{
+	UNUSED(win);
+	UNUSED(errcode);
+
+	uprintf("Window handlers not supported yet.");
+}
+
+/*============================================================================*
+ * MPI_ERRORS_ABORT                                                           *
+ *============================================================================*/
+
+PUBLIC void mpi_errors_abort_comm_handler(mpi_communicator_t **comm,
+                                          int *errcode, ...)
+{
+	mpi_communicator_t *abort_comm;
+	va_list arglist;
+
+	va_start(arglist, errcode);
+
+	/* If no comm passed as argument, propagates the error through MPI_COMM_SELF. */
+	if (comm == NULL)
+		abort_comm = &_mpi_comm_self;
+	else
+		abort_comm = *comm;
+
+	backend_abort(abort_comm, errcode, arglist);
+}
+
+PUBLIC void mpi_errors_abort_file_handler(mpi_file_t **file,
+                                          int *errcode, ...)
+{
+	UNUSED(file);
+	UNUSED(errcode);
+
+	uprintf("File handlers not supported yet.");
+}
+
+PUBLIC void mpi_errors_abort_win_handler(mpi_win_t **win,
+                                         int *errcode, ...)
+{
+	UNUSED(win);
+	UNUSED(errcode);
+
+	uprintf("Window handlers not supported yet.");
+}
+
+/*============================================================================*
+ * MPI_ERRORS_RETURN                                                          *
+ *============================================================================*/
+
+PUBLIC void mpi_errors_return_comm_handler(mpi_communicator_t **comm,
+                                           int *errcode, ...)
+{
+	/* Do nothing. Errcode will already be returned to the user. */
+	/* @note Don't remove this piece of code. It makes compiler happy. */
+	va_list arglist;
+	va_start(arglist, errcode);
+	va_end(arglist);
+
+	UNUSED(comm);
+	UNUSED(errcode);
+}
+
+PUBLIC void mpi_errors_return_file_handler(mpi_file_t **file,
+                                           int *errcode, ...)
+{
+	UNUSED(file);
+	UNUSED(errcode);
+
+	uprintf("File handlers not supported yet.");
+}
+
+PUBLIC void mpi_errors_return_win_handler(mpi_win_t **win,
+                                          int *errcode, ...)
+{
+	UNUSED(win);
+	UNUSED(errcode);
+
+	uprintf("Window handlers not supported yet.");
+}
+
+/*
+ * Note that this function has to handle pre-MPI_INIT and
+ * post-MPI_FINALIZE errors, which backend_fatal_aggregate() does not
+ * have to handle.
+ *
+ * This function also intentionally does not call malloc(), just in
+ * case we're being called due to some kind of stack/memory error --
+ * we *might* be able to get a message out if we're not further
+ * corrupting the stack by calling malloc()...
+ */
+static void print_error_message(int *errcode, va_list arglist)
+{
+	int state;
+	char *arg;
+
+	state = _mpi_state;
+	arg = va_arg(arglist, char*);
+
+	if (state < MPI_STATE_INIT_STARTED)
+	{
+		if (arg == NULL)
+		{
+			uprintf("ERROR!!! A function was called before MPI_Init() was invoked, what " \
+			        "is not allowed by the MPI standard.");
+		}
+		else
+		{
+			uprintf("ERROR!!! %s() function called before MPI_Init() was invoked, what " \
+			        "is not allowed by the MPI standard.", arg);
+		}
+	}
+	else if (state >= MPI_STATE_FINALIZE_STARTED)
+	{
+		if (arg == NULL)
+		{
+			uprintf("ERROR!!! A function was called after MPI_Finalize() was invoked, what" \
+			        "is not allowed by the MPI standard.");
+		}
+		else
+		{
+			uprintf("ERROR!!! %s() function called after MPI_Finalize() was invoked, what" \
+			        "is not allowed by the MPI standard.", arg);
+		}
+	}
+	else
+	{
+		if (arg == NULL)
+			uprintf("ERROR!!!");
+		else
+			uprintf("ERROR!!! %s", arg);
+
+		if (errcode != NULL)
+			uprintf("Error code: %d", *errcode);
+	}
+
+	va_end(arglist);
+}
+
+static void backend_abort(mpi_communicator_t *comm, int *errcode, va_list arglist)
+{
+	print_error_message(errcode, arglist);
+
+	if (errcode != NULL)
+		mpi_abort(comm, *errcode);
+	else
+		mpi_abort(comm, 1);
+}

--- a/src/mpi/makefile
+++ b/src/mpi/makefile
@@ -49,8 +49,10 @@ LIBS += $(LIBDIR)/$(BARELIB) $(THEIR_LIBS)
 #===============================================================================
 
 # C Source Files
-SRC = $(wildcard group/*.c) \
-      $(wildcard communicator/*.c)
+SRC = $(wildcard group/*.c)        \
+      $(wildcard communicator/*.c) \
+      $(wildcard errhandler/*.c)   \
+      $(wildcard runtime/*.c)
 
 #===============================================================================
 # Object Files

--- a/src/mpi/runtime/runtime.c
+++ b/src/mpi/runtime/runtime.c
@@ -1,0 +1,60 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/hlib.h>
+#include <nanvix/ulib.h>
+#include <posix/errno.h>
+#include <mpi/mpiruntime.h>
+
+/**
+ * @brief Global MPI state variable.
+ */
+mpi_state_t _mpi_state = MPI_STATE_NOT_INITIALIZED;
+
+/**
+ * @see mpi_init() at mpiruntime.h.
+ */
+PUBLIC int mpi_init(void)
+{
+	return (MPI_SUCCESS);
+}
+
+/**
+ * @see mpi_finalize() at mpiruntime.h.
+ */
+PUBLIC int mpi_finalize(void)
+{
+	return (MPI_SUCCESS);
+}
+
+/**
+ * @see mpi_abort() at mpiruntime.h.
+ */
+PUBLIC int mpi_abort(mpi_communicator_t *comm, int errorcode)
+{
+	UNUSED(comm);
+	UNUSED(errorcode);
+
+	return (MPI_SUCCESS);
+}

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -28,6 +28,7 @@
 #include <mputil/object.h>
 #include <mpi/group.h>
 #include <mpi/communicator.h>
+#include <mpi/errhandler.h>
 #include <mpi.h>
 
 /**
@@ -36,11 +37,15 @@
 int __main2(int argc, const char *argv[])
 {
 	mpi_process_t *local;
-	mpi_group_t *group;
+	MPI_Group group;
 	UNUSED(argc);
 	UNUSED(argv);
 
 	uprintf("---------------------------------------------");
+
+	uassert(mpi_errhandler_init() == 0);
+
+	uprintf("Error handling system initialized");
 
 	uassert(mpi_proc_init() == 0);
 
@@ -105,6 +110,10 @@ int __main2(int argc, const char *argv[])
 	uassert(mpi_proc_finalize() == 0);
 
 	uprintf("Proc system finalized");
+
+	uassert(mpi_errhandler_finalize() == 0);
+
+	uprintf("Error handling system finalized");
 
 	uprintf("Successful!");
 


### PR DESCRIPTION
# Description #
In this PR we introduce a first draft of MPI_Errhandlers. Were implemented the three basic MPI Error handlers for communicators, `MPI_ERRORS_ABORT`, `MPI_ERRORS_ARE_FATAL`, `MPI_ERRORS_RETURN`, and their interfaces to be expanded when Windows and Files become supported by this library.
Also, a MPI Runtime interface was defined, with some important function signatures and global variables that are used to control the MPI execution environment.

# Related Issues #
- Closes #9 - [mpi] MPI_Errhandlers