### PR TITLE
[mpi] Point-to-point Communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,10 +32,7 @@ include/nanvix/cc.h
 include/nanvix/const.h
 include/nanvix/hal.h
 include/nanvix/hlib.h
-include/posix/sys/_intsup.h
-include/posix/sys/features.h
-include/posix/sys/types.h
-include/posix/sys/stat.h
+include/posix/sys/*
 include/posix/decl.h
 include/posix/errno.h
 include/posix/fcntl.h

--- a/include/mpi.h
+++ b/include/mpi.h
@@ -26,6 +26,16 @@
 #define NANVIX_LIBMPI_MPI_H_
 
 #include <posix/stdint.h>
+#include <mpi/mpi_errors.h>
+
+/**
+ * @brief Defines the Upper bound for tag values.
+ *
+ * @note This constant is implementation dependant and 32767 is the minimum value.
+ *
+ * @todo See where to define this constant correctly.
+ */
+#define UB 32768
 
 /**
  * @note Temporary definitions. Declared only for convenience on errhandlers definition.
@@ -123,91 +133,6 @@ typedef void MPI_File_errhandler_function(MPI_File *, int *, ...);
 #define MPI_UNEQUAL   3
 
 /**
- * @brief Error Codes and Classes.
- */
-#define MPI_SUCCESS                    0 /* No error. */
-#define MPI_ERR_BUFFER                 1 /* Invalid buffer pointer. */
-#define MPI_ERR_COUNT                  2 /* Invalid count argument. */
-#define MPI_ERR_TYPE                   3 /* Invalid datatype argument. */
-#define MPI_ERR_TAG                    4 /* Invalid tag argument. */
-#define MPI_ERR_COMM                   5 /* Invalid communicator. */
-#define MPI_ERR_RANK                   6 /* Invalid rank. */
-#define MPI_ERR_REQUEST                7 /* Invalid request (handle). */
-#define MPI_ERR_ROOT                   8 /* Invalid root. */
-#define MPI_ERR_GROUP                  9 /* Invalid group. */
-#define MPI_ERR_OP                    10 /* Invalid operation. */
-#define MPI_ERR_TOPOLOGY              11 /* Invalid topology. */
-#define MPI_ERR_DIMS                  12 /* Invalid dimension argument. */
-#define MPI_ERR_ARG                   13 /* Invalid argument of other kind. */
-#define MPI_ERR_UNKNOWN               14 /* Unknown error. */
-#define MPI_ERR_TRUNCATE              15 /* Message truncated on receive. */
-#define MPI_ERR_OTHER                 16 /* Known error not in this list. */
-#define MPI_ERR_INTERN                17 /* Internal MPI impl error. */
-#define MPI_ERR_PENDING               18 /* Pending request. */
-#define MPI_ERR_IN_STATUS             19 /* Error code is in status. */
-#define MPI_ERR_ACCESS                20 /* Permission denied. */
-#define MPI_ERR_AMODE                 21 /* Error related to amode on I/O. */
-#define MPI_ERR_ASSERT                22 /* Invalid assert argument. */
-#define MPI_ERR_BAD_FILE              23 /* Invalid file name. */
-#define MPI_ERR_BASE                  24 /* Invalid base to MPI_FREE_MEM. */
-#define MPI_ERR_CONVERSION            25 /* Error in a user conv function. */
-#define MPI_ERR_DISP                  26 /* Invalid disp argument. */
-#define MPI_ERR_DUP_DATAREP           27 /* Already defined data representation. */
-#define MPI_ERR_FILE_EXISTS           28 /* File exists. */
-#define MPI_ERR_FILE_IN_USE           29 /* File currently open by some process. */
-#define MPI_ERR_FILE                  30 /* Invalid file handle. */
-#define MPI_ERR_INFO_KEY              31 /* Key longer than MPI_MAX_INFO_KEY. */
-#define MPI_ERR_INFO_NOKEY            32 /* Invalid key to MPI_INFO_DELETE. */
-#define MPI_ERR_INFO_VALUE            33 /* Value longer than MPI_MAX_INFO_VAL. */
-#define MPI_ERR_INFO                  34 /* Invalid info argument. */
-#define MPI_ERR_IO                    35 /* Other I/O error. */
-#define MPI_ERR_KEYVAL                36 /* Invalid keyval has been passed. */
-#define MPI_ERR_LOCKTYPE              37 /* Invalid locktype argument. */
-#define MPI_ERR_NAME                  38 /* Invalid srvc name to MPI_LOOKUP_NAME. */
-#define MPI_ERR_NO_MEM                39 /* Memory is exhausted. */
-#define MPI_ERR_NOT_SAME              40 /* Collective arg not identical on all procs. */
-#define MPI_ERR_NO_SPACE              41 /* Not enough space. */
-#define MPI_ERR_NO_SUCH_FILE          42 /* File does not exist. */
-#define MPI_ERR_PORT                  43 /* Invalid port name to MPI_COMM_CONNECT. */
-#define MPI_ERR_QUOTA                 44 /* Quota exceeded. */
-#define MPI_ERR_READ_ONLY             45 /* Read-only file or file system. */
-#define MPI_ERR_RMA_ATTACH            46
-#define MPI_ERR_RMA_CONFLICT          47 /* Conflicting accesses to window. */
-#define MPI_ERR_RMA_RANGE             48
-#define MPI_ERR_RMA_SHARED            49
-#define MPI_ERR_RMA_SYNC              50 /* Wrong synchronization of RMA calls. */
-#define MPI_ERR_RMA_FLAVOR            51
-#define MPI_ERR_SERVICE               52 /* Invalid srvc nameto MPI_UNPUBLISH_NAME. */
-#define MPI_ERR_SIZE                  53 /* Invalid size argument. */
-#define MPI_ERR_SPAWN                 54 /* Error in spawning processes. */
-#define MPI_ERR_UNSUPPORTED_DATAREP   55 /* Unsupp datarep to MPI_FILE_SET_VIEW. */
-#define MPI_ERR_UNSUPPORTED_OPERATION 56 /* Unsupported operation. */
-#define MPI_ERR_WIN                   57 /* Invalid win argument. */
-#define MPI_T_ERR_CANNOT_INIT         58
-#define MPI_T_ERR_NOT_INITIALIZED     59
-#define MPI_T_ERR_MEMORY              60
-#define MPI_T_ERR_INVALID             61
-#define MPI_T_ERR_INVALID_INDEX       62
-#define MPI_T_ERR_INVALID_ITEM        63
-#define MPI_T_ERR_INVALID_SESSION     64
-#define MPI_T_ERR_INVALID_HANDLE      65
-#define MPI_T_ERR_INVALID_NAME        66
-#define MPI_T_ERR_OUT_OF_HANDLES      67
-#define MPI_T_ERR_OUT_OF_SESSIONS     68
-#define MPI_T_ERR_CVAR_SET_NOT_NOW    69
-#define MPI_T_ERR_CVAR_SET_NEVER      70
-#define MPI_T_ERR_PVAR_NO_WRITE       71
-#define MPI_T_ERR_PVAR_NO_STARTSTOP   72
-#define MPI_T_ERR_PVAR_NO_ATOMIC      73
-
-/**
- * @note Used to sanytize codes validity. Should gave some room for user added error codes.
- */
-#define MPI_ERR_LASTCODE              92 /* Last error code . */
-
-/* End of error classes definitions. */
-
-/**
  * @brief Supported thread levels constants.
  */
 #define MPI_THREAD_SINGLE     0
@@ -218,40 +143,40 @@ typedef void MPI_File_errhandler_function(MPI_File *, int *, ...);
 /**
  * @brief Predefined MPI_Datatype external structures.
  */
-extern const struct mpi_datatype_t _mpi_datatype_char;
-extern const struct mpi_datatype_t _mpi_datatype_short;
-extern const struct mpi_datatype_t _mpi_datatype_int;
-extern const struct mpi_datatype_t _mpi_datatype_long;
-extern const struct mpi_datatype_t _mpi_datatype_long_long;
-extern const struct mpi_datatype_t _mpi_datatype_long_long;
-extern const struct mpi_datatype_t _mpi_datatype_signed_char;
-extern const struct mpi_datatype_t _mpi_datatype_unsigned_char;
-extern const struct mpi_datatype_t _mpi_datatype_unsigned_short;
-extern const struct mpi_datatype_t _mpi_datatype_unsigned;
-extern const struct mpi_datatype_t _mpi_datatype_unsigned_long;
-extern const struct mpi_datatype_t _mpi_datatype_unsigned_long_long;
-extern const struct mpi_datatype_t _mpi_datatype_float;
-extern const struct mpi_datatype_t _mpi_datatype_double;
-extern const struct mpi_datatype_t _mpi_datatype_long_double;
-extern const struct mpi_datatype_t _mpi_datatype_wchar;
-extern const struct mpi_datatype_t _mpi_datatype_cbool;
-extern const struct mpi_datatype_t _mpi_datatype_int8;
-extern const struct mpi_datatype_t _mpi_datatype_int16;
-extern const struct mpi_datatype_t _mpi_datatype_int32;
-extern const struct mpi_datatype_t _mpi_datatype_int64;
-extern const struct mpi_datatype_t _mpi_datatype_uint8;
-extern const struct mpi_datatype_t _mpi_datatype_uint16;
-extern const struct mpi_datatype_t _mpi_datatype_uint32;
-extern const struct mpi_datatype_t _mpi_datatype_uint64;
-extern const struct mpi_datatype_t _mpi_datatype_ccomplex;
-extern const struct mpi_datatype_t _mpi_datatype_ccomplex;
-extern const struct mpi_datatype_t _mpi_datatype_double_complex;
-extern const struct mpi_datatype_t _mpi_datatype_long_double_complex;
-extern const struct mpi_datatype_t _mpi_datatype_byte;
-extern const struct mpi_datatype_t _mpi_datatype_packed;
-extern const struct mpi_datatype_t _mpi_datatype_aint;
-extern const struct mpi_datatype_t _mpi_datatype_offset;
-extern const struct mpi_datatype_t _mpi_datatype_count;
+extern struct mpi_datatype_t _mpi_datatype_char;
+extern struct mpi_datatype_t _mpi_datatype_short;
+extern struct mpi_datatype_t _mpi_datatype_int;
+extern struct mpi_datatype_t _mpi_datatype_long;
+extern struct mpi_datatype_t _mpi_datatype_long_long;
+extern struct mpi_datatype_t _mpi_datatype_long_long;
+extern struct mpi_datatype_t _mpi_datatype_signed_char;
+extern struct mpi_datatype_t _mpi_datatype_unsigned_char;
+extern struct mpi_datatype_t _mpi_datatype_unsigned_short;
+extern struct mpi_datatype_t _mpi_datatype_unsigned;
+extern struct mpi_datatype_t _mpi_datatype_unsigned_long;
+extern struct mpi_datatype_t _mpi_datatype_unsigned_long_long;
+extern struct mpi_datatype_t _mpi_datatype_float;
+extern struct mpi_datatype_t _mpi_datatype_double;
+extern struct mpi_datatype_t _mpi_datatype_long_double;
+extern struct mpi_datatype_t _mpi_datatype_wchar;
+extern struct mpi_datatype_t _mpi_datatype_cbool;
+extern struct mpi_datatype_t _mpi_datatype_int8;
+extern struct mpi_datatype_t _mpi_datatype_int16;
+extern struct mpi_datatype_t _mpi_datatype_int32;
+extern struct mpi_datatype_t _mpi_datatype_int64;
+extern struct mpi_datatype_t _mpi_datatype_uint8;
+extern struct mpi_datatype_t _mpi_datatype_uint16;
+extern struct mpi_datatype_t _mpi_datatype_uint32;
+extern struct mpi_datatype_t _mpi_datatype_uint64;
+extern struct mpi_datatype_t _mpi_datatype_ccomplex;
+extern struct mpi_datatype_t _mpi_datatype_ccomplex;
+extern struct mpi_datatype_t _mpi_datatype_double_complex;
+extern struct mpi_datatype_t _mpi_datatype_long_double_complex;
+extern struct mpi_datatype_t _mpi_datatype_byte;
+extern struct mpi_datatype_t _mpi_datatype_packed;
+extern struct mpi_datatype_t _mpi_datatype_aint;
+extern struct mpi_datatype_t _mpi_datatype_offset;
+extern struct mpi_datatype_t _mpi_datatype_count;
 
 /**
  * @brief Predefined datatypes.

--- a/include/mpi.h
+++ b/include/mpi.h
@@ -43,6 +43,8 @@ typedef struct mpi_group_t        *MPI_Group;
 typedef struct mpi_win_t          *MPI_Win;
 typedef struct mpi_file_t         *MPI_File;
 typedef struct mpi_errhandler_t   *MPI_Errhandler;
+typedef struct mpi_datatype_t     *MPI_Datatype;
+typedef struct mpi_status_t        MPI_Status;
 
 /**
  * @brief Another predefined datatypes.
@@ -50,6 +52,25 @@ typedef struct mpi_errhandler_t   *MPI_Errhandler;
 typedef uint64_t *MPI_Aint;
 typedef uint64_t *MPI_Count;
 typedef uint64_t *MPI_Offset;
+
+/**
+ * @brief MPI_Status definition.
+ *
+ * @note Defined here cause MPI Specification defines that this struct
+ * has public fields that may be accessed by the user.
+ */
+struct mpi_status_t
+{
+	int MPI_SOURCE; /* MPI message sender.     */
+	int MPI_TAG;    /* MPI message tag.        */
+	int MPI_ERROR;  /* MPI message error code. */
+
+	/**
+	 * @note The following fields are internal to the MPI implementation and
+	 * should not be directly accessed, besides the implementation itself.
+	 */
+	int received_size; /* Received size in transfer. */
+};
 
 /**
  * @brief User exported function typedefs.
@@ -71,6 +92,12 @@ typedef void MPI_File_errhandler_function(MPI_File *, int *, ...);
 #define MPI_MAX_PROCESSOR_NAME         128
 
 /* End of assorted constants. */
+
+/**
+ * @brief Special STATUS constants.
+ */
+#define MPI_STATUS_IGNORE   NULL
+#define MPI_STATUSES_IGNORE NULL
 
 /**
  * @brief Assorted constants.
@@ -310,10 +337,13 @@ extern int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler);
 extern int MPI_Errhandler_free(MPI_Errhandler *errhandler);
 extern int MPI_Finalize(void);
 extern int MPI_Finalized(int *flag);
+extern int MPI_Get_count(const MPI_Status *status, MPI_Datatype datatype, int *count);
 extern int MPI_Group_rank(MPI_Group group, int *rank);
 extern int MPI_Group_size(MPI_Group group, int *size);
 extern int MPI_Group_free(MPI_Group *group);
 extern int MPI_Init(int *argc, char ***argv);
 extern int MPI_Initialized(int *flag);
+extern int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status);
+extern int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
 
 #endif /* NANVIX_LIBMPI_H_ */

--- a/include/mpi/communicator.h
+++ b/include/mpi/communicator.h
@@ -25,6 +25,7 @@
 #ifndef NANVIX_MPI_COMMUNICATOR_H_
 #define NANVIX_MPI_COMMUNICATOR_H_
 
+#include <nanvix/hlib.h>
 #include <mputil/object.h>
 #include <mpi/group.h>
 #include <mpi/errhandler.h>
@@ -107,6 +108,33 @@ static inline int mpi_comm_size(mpi_communicator_t * comm)
 static inline int mpi_comm_get_pt2pt_cid(mpi_communicator_t* comm)
 {
     return (comm->pt2pt_cid);
+}
+
+/**
+ * @brief Checks if a communicator pointer is valid.
+ *
+ * @param comm Target communicator.
+ *
+ * @returns Zero if the communicator is not valid, and a non-zero
+ * value otherwise.
+ */
+static inline int mpi_comm_is_valid(mpi_communicator_t* comm)
+{
+    return ((comm != NULL) && (comm != MPI_COMM_NULL));
+}
+
+/**
+ * @brief Checks if a peer rank is inside the comm range.
+ *
+ * @param comm Target communicator.
+ * @param rank Peer rank to be evaluated.
+ *
+ * @returns Zero if the rank is not in the comm range, and a non-zero
+ * value otherwise.
+ */
+static inline int mpi_comm_peer_rank_is_valid(mpi_communicator_t* comm, int rank)
+{
+    return (WITHIN(rank, 0, mpi_group_size(comm->group)));
 }
 
 /**

--- a/include/mpi/communicator.h
+++ b/include/mpi/communicator.h
@@ -162,6 +162,19 @@ static inline int mpi_comm_get_coll_cid(mpi_communicator_t* comm)
 extern int mpi_comm_group(mpi_communicator_t *comm, mpi_group_t **group);
 
 /**
+ * @brief Extracts the proc with rank @p rank in @p comm.
+ *
+ * @param comm The target communicator.
+ * @param rank The associated rank of the desired proc.
+ * @param proc Pointer to receive the process reference.
+ *
+ * @returns Upon successful completion, MPI_SUCCESS is returned with the
+ * proc reference on @p proc. An MPI_ERROR_CODE is returned instead with
+ * proc pointing to NULL.
+ */
+extern int mpi_comm_get_proc(mpi_communicator_t *comm, int rank, mpi_process_t **proc);
+
+/**
  * @brief Initializes the communicators submodule.
  *
  * @returns Upon successful completion, zero is returned. A

--- a/include/mpi/datatype.h
+++ b/include/mpi/datatype.h
@@ -60,6 +60,19 @@ static inline int mpi_datatype_size(const mpi_datatype_t *datatype, int *size)
 }
 
 /**
+ * @brief Checks if a datatype pointer is valid.
+ *
+ * @param type Target datatype.
+ *
+ * @returns Zero if the datatype is not valid, and a non-zero
+ * value otherwise.
+ */
+static inline int mpi_datatype_is_valid(mpi_datatype_t* type)
+{
+    return ((type != NULL) && (type != MPI_DATATYPE_NULL));
+}
+
+/**
  * @brief Initializes the datatypes submodule.
  *
  * @returns Upon successful completion, zero is returned. A

--- a/include/mpi/datatype.h
+++ b/include/mpi/datatype.h
@@ -34,10 +34,10 @@
  */
 struct mpi_datatype_t
 {
-	object_t super; /* Base object class.                           */
+	object_t super; /* Base object class.                */
 
-	uint16_t id;    /* Index in the datatypes array.                */
-	int size;       /* Total size in memory bytes used by the data. */
+	uint16_t id;    /* Index in the datatypes array.     */
+	int size;       /* Total size in bytes used by data. */
 };
 
 typedef struct mpi_datatype_t mpi_datatype_t;
@@ -49,14 +49,27 @@ OBJ_CLASS_DECLARATION(mpi_datatype_t);
  * @brief Gets the size of the given datatype.
  *
  * @param datatype The target datatype.
- * @param size     Output variable to hold the datatype size.
  *
- * @returns Returns zero, with sizeof datatype in @p size.
+ * @returns Returns the size of @p datatype.
  */
-static inline int mpi_datatype_size(const mpi_datatype_t *datatype, int *size)
+static inline size_t mpi_datatype_size(const mpi_datatype_t *datatype)
 {
-    *size = datatype->size;
-    return (0);
+	uassert(datatype != NULL);
+	return (datatype->size);
+}
+
+/**
+ * @brief Gets the ID associated to @p datatype.
+ *
+ * @param datatype Target datatype.
+ *
+ * @returns Upon receiving a valid datatype, the id associated to @p datatype
+ * is returned. A negative error code is returned instead.
+ */
+static inline int mpi_datatype_id(const mpi_datatype_t *datatype)
+{
+	uassert(datatype != NULL);
+	return (datatype->id);
 }
 
 /**
@@ -69,8 +82,19 @@ static inline int mpi_datatype_size(const mpi_datatype_t *datatype, int *size)
  */
 static inline int mpi_datatype_is_valid(mpi_datatype_t* type)
 {
-    return ((type != NULL) && (type != MPI_DATATYPE_NULL));
+	return ((type != NULL) && (type != MPI_DATATYPE_NULL));
 }
+
+/**
+ * @brief Compares two different datatypes and evaluates if they match.
+ *
+ * @param type1 First datatype.
+ * @param type2 The datatype to be compared.
+ *
+ * @returns Zero if the datatypes don't match, and a Non-zero value
+ * otherwise.
+ */
+extern int mpi_datatypes_match(int type1, int type2);
 
 /**
  * @brief Initializes the datatypes submodule.

--- a/include/mpi/errhandler.h
+++ b/include/mpi/errhandler.h
@@ -139,6 +139,19 @@ extern int mpi_errhandler_invoke(mpi_errhandler_t *errhandler, void *mpi_object,
                                  int type, int errcode, const char *message);
 
 /**
+ * @brief Checks if an error handler pointer is valid.
+ *
+ * @param errhandler Target error handler.
+ *
+ * @returns Zero if the error handler is not valid, and a non-zero
+ * value otherwise.
+ */
+static inline int mpi_errhandler_is_valid(mpi_errhandler_t* errhandler)
+{
+    return ((errhandler != NULL) && (errhandler != MPI_ERRHANDLER_NULL));
+}
+
+/**
  * @brief Initializes the error handling submodule.
  *
  * @returns Upon successful completion, zero is returned. A

--- a/include/mpi/group.h
+++ b/include/mpi/group.h
@@ -126,6 +126,19 @@ static inline int mpi_group_rank(mpi_group_t * group)
 extern void mpi_group_set_rank(mpi_group_t * group, mpi_process_t * proc);
 
 /**
+ * @brief Gets the proc associated with rank @p rank.
+ *
+ * @param group Target group.
+ * @param rank  Target rank.
+ * @param proc  Pointer to hold the target process reference.
+ *
+ * @returns Upon successful completion, MPI_SUCCESS is returned and @p proc
+ * points to the desired proc. Uṕon failure, an MPI Error code is returned with
+ * @p proc pointing to NULL.
+ */
+extern int mpi_group_get_proc(mpi_group_t *group, int rank, mpi_process_t **proc);
+
+/**
  * @brief Increments the refcount of each process in @p group.
  *
  * @param group Group of processes to be manipulated.

--- a/include/mpi/group.h
+++ b/include/mpi/group.h
@@ -79,6 +79,19 @@ extern mpi_group_t * mpi_group_allocate_w_procs(mpi_process_t ** procs, int grou
 extern int mpi_group_free(mpi_group_t ** group);
 
 /**
+ * @brief Checks if a group pointer is valid.
+ *
+ * @param group Target group.
+ *
+ * @returns Zero if the group is not valid, and a non-zero
+ * value otherwise.
+ */
+static inline int mpi_group_is_valid(mpi_group_t* group)
+{
+    return ((group != NULL) && (group != MPI_GROUP_NULL));
+}
+
+/**
  * @brief Gets the group size.
  *
  * @param group Group descriptor.

--- a/include/mpi/mpi_errors.h
+++ b/include/mpi/mpi_errors.h
@@ -1,0 +1,111 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_MPI_ERRORS_H_
+#define NANVIX_MPI_ERRORS_H_
+
+/**
+ * @brief Error Codes and Classes.
+ */
+#define MPI_SUCCESS                    0 /* No error. */
+#define MPI_ERR_BUFFER                 1 /* Invalid buffer pointer. */
+#define MPI_ERR_COUNT                  2 /* Invalid count argument. */
+#define MPI_ERR_TYPE                   3 /* Invalid datatype argument. */
+#define MPI_ERR_TAG                    4 /* Invalid tag argument. */
+#define MPI_ERR_COMM                   5 /* Invalid communicator. */
+#define MPI_ERR_RANK                   6 /* Invalid rank. */
+#define MPI_ERR_REQUEST                7 /* Invalid request (handle). */
+#define MPI_ERR_ROOT                   8 /* Invalid root. */
+#define MPI_ERR_GROUP                  9 /* Invalid group. */
+#define MPI_ERR_OP                    10 /* Invalid operation. */
+#define MPI_ERR_TOPOLOGY              11 /* Invalid topology. */
+#define MPI_ERR_DIMS                  12 /* Invalid dimension argument. */
+#define MPI_ERR_ARG                   13 /* Invalid argument of other kind. */
+#define MPI_ERR_UNKNOWN               14 /* Unknown error. */
+#define MPI_ERR_TRUNCATE              15 /* Message truncated on receive. */
+#define MPI_ERR_OTHER                 16 /* Known error not in this list. */
+#define MPI_ERR_INTERN                17 /* Internal MPI impl error. */
+#define MPI_ERR_PENDING               18 /* Pending request. */
+#define MPI_ERR_IN_STATUS             19 /* Error code is in status. */
+#define MPI_ERR_ACCESS                20 /* Permission denied. */
+#define MPI_ERR_AMODE                 21 /* Error related to amode on I/O. */
+#define MPI_ERR_ASSERT                22 /* Invalid assert argument. */
+#define MPI_ERR_BAD_FILE              23 /* Invalid file name. */
+#define MPI_ERR_BASE                  24 /* Invalid base to MPI_FREE_MEM. */
+#define MPI_ERR_CONVERSION            25 /* Error in a user conv function. */
+#define MPI_ERR_DISP                  26 /* Invalid disp argument. */
+#define MPI_ERR_DUP_DATAREP           27 /* Already defined data representation. */
+#define MPI_ERR_FILE_EXISTS           28 /* File exists. */
+#define MPI_ERR_FILE_IN_USE           29 /* File currently open by some process. */
+#define MPI_ERR_FILE                  30 /* Invalid file handle. */
+#define MPI_ERR_INFO_KEY              31 /* Key longer than MPI_MAX_INFO_KEY. */
+#define MPI_ERR_INFO_NOKEY            32 /* Invalid key to MPI_INFO_DELETE. */
+#define MPI_ERR_INFO_VALUE            33 /* Value longer than MPI_MAX_INFO_VAL. */
+#define MPI_ERR_INFO                  34 /* Invalid info argument. */
+#define MPI_ERR_IO                    35 /* Other I/O error. */
+#define MPI_ERR_KEYVAL                36 /* Invalid keyval has been passed. */
+#define MPI_ERR_LOCKTYPE              37 /* Invalid locktype argument. */
+#define MPI_ERR_NAME                  38 /* Invalid srvc name to MPI_LOOKUP_NAME. */
+#define MPI_ERR_NO_MEM                39 /* Memory is exhausted. */
+#define MPI_ERR_NOT_SAME              40 /* Collective arg not identical on all procs. */
+#define MPI_ERR_NO_SPACE              41 /* Not enough space. */
+#define MPI_ERR_NO_SUCH_FILE          42 /* File does not exist. */
+#define MPI_ERR_PORT                  43 /* Invalid port name to MPI_COMM_CONNECT. */
+#define MPI_ERR_QUOTA                 44 /* Quota exceeded. */
+#define MPI_ERR_READ_ONLY             45 /* Read-only file or file system. */
+#define MPI_ERR_RMA_ATTACH            46
+#define MPI_ERR_RMA_CONFLICT          47 /* Conflicting accesses to window. */
+#define MPI_ERR_RMA_RANGE             48
+#define MPI_ERR_RMA_SHARED            49
+#define MPI_ERR_RMA_SYNC              50 /* Wrong synchronization of RMA calls. */
+#define MPI_ERR_RMA_FLAVOR            51
+#define MPI_ERR_SERVICE               52 /* Invalid srvc nameto MPI_UNPUBLISH_NAME. */
+#define MPI_ERR_SIZE                  53 /* Invalid size argument. */
+#define MPI_ERR_SPAWN                 54 /* Error in spawning processes. */
+#define MPI_ERR_UNSUPPORTED_DATAREP   55 /* Unsupp datarep to MPI_FILE_SET_VIEW. */
+#define MPI_ERR_UNSUPPORTED_OPERATION 56 /* Unsupported operation. */
+#define MPI_ERR_WIN                   57 /* Invalid win argument. */
+#define MPI_T_ERR_CANNOT_INIT         58
+#define MPI_T_ERR_NOT_INITIALIZED     59
+#define MPI_T_ERR_MEMORY              60
+#define MPI_T_ERR_INVALID             61
+#define MPI_T_ERR_INVALID_INDEX       62
+#define MPI_T_ERR_INVALID_ITEM        63
+#define MPI_T_ERR_INVALID_SESSION     64
+#define MPI_T_ERR_INVALID_HANDLE      65
+#define MPI_T_ERR_INVALID_NAME        66
+#define MPI_T_ERR_OUT_OF_HANDLES      67
+#define MPI_T_ERR_OUT_OF_SESSIONS     68
+#define MPI_T_ERR_CVAR_SET_NOT_NOW    69
+#define MPI_T_ERR_CVAR_SET_NEVER      70
+#define MPI_T_ERR_PVAR_NO_WRITE       71
+#define MPI_T_ERR_PVAR_NO_STARTSTOP   72
+#define MPI_T_ERR_PVAR_NO_ATOMIC      73
+
+/**
+ * @note Used to sanytize codes validity. Should gave some room for user added error codes.
+ */
+#define MPI_ERR_LASTCODE              92 /* Last error code . */
+
+#endif /* NANVIX_MPI_ERRORS_H_ */

--- a/include/mpi/pt2pt_comm.h
+++ b/include/mpi/pt2pt_comm.h
@@ -1,0 +1,55 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_MPI_PT2PT_COMM_H_
+#define NANVIX_MPI_PT2PT_COMM_H_
+
+#include <mpi.h>
+
+/**
+ * @brief MPI Point-to-point communication modes.
+ *
+ * @note This enumeration should be in accord with the underlying constants
+ * defined in mputil/comm_context.h whose defines the communication protocols
+ * available in the underlying levels.
+ */
+typedef enum {
+	READY_MODE,
+	BUFFERED_MODE,
+	SYNC_MODE
+} mpi_comm_mode_t;
+
+/**
+ * @brief Provide detailed description.
+ */
+extern int mpi_send(const void *buf, int count, MPI_Datatype datatype, int dest,
+	                int tag, MPI_Comm comm, mpi_comm_mode_t mode);
+
+/**
+ * @brief Provide detailed description.
+ */
+extern int mpi_recv(void *buf, int count, MPI_Datatype datatype, int source,
+	                int tag, MPI_Comm comm, MPI_Status *status);
+
+#endif /* NANVIX_MPI_PT2PT_COMM_H_ */

--- a/include/mputil/comm_context.h
+++ b/include/mputil/comm_context.h
@@ -1,0 +1,80 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_COMM_CONTEXT_H_
+#define NANVIX_COMM_CONTEXT_H_
+
+#include <nanvix/limits.h>
+
+/**
+ * @brief Defines the first context ID available for MPI communicators.
+ *
+ * @note Constant defined in nanvix/limits/pm.h.
+ */
+#define MPI_CONTEXT_BASE NANVIX_GENERAL_PORTS_BASE
+
+/**
+ * @brief Defines the max number of contexts to be allocated (excluding predefined).
+ */
+#define MPI_CONTEXTS_ALLOCATE_MAX 0
+
+/**
+ * @brief Struct that defines a basic communication context.
+ */
+struct mpi_comm_context
+{
+	int port;              /* Context port number. */
+	int inbox;             /* Inbox ID.            */
+	int inportal;          /* Inportal ID.         */
+	uint8_t is_collective; /* Collective context?  */
+};
+
+/**
+ * @brief Allocates a context and propagates it through the other processes.
+ *
+ * @returns An integer relative to the newly allocated context ID.
+ *
+ * @todo Implement this function when new communicators creation become available.
+ * It may be necessary the implementation of a consensus protocol here, based on the
+ * MPI_COMM_WORLD.
+ */
+extern int comm_context_allocate(void);
+
+/**
+ * @brief Initializes the contexts submodule.
+ *
+ * @returns Upon successful completion, zero is returned. A
+ * negative MPI error code is returned instead.
+ */
+extern int comm_context_init(void);
+
+/**
+ * @brief Finalizes the contexts submodule.
+ *
+ * @returns Upon successful completion, zero is returned. A
+ * negative error code is returned instead.
+ */
+extern int comm_context_finalize(void);
+
+#endif /* NANVIX_COMM_CONTEXT_H_ */

--- a/include/mputil/comm_context.h
+++ b/include/mputil/comm_context.h
@@ -26,6 +26,8 @@
 #define NANVIX_COMM_CONTEXT_H_
 
 #include <nanvix/limits.h>
+#include <mputil/proc.h>
+#include <mputil/comm_request.h>
 
 /**
  * @brief Defines the first context ID available for MPI communicators.
@@ -38,6 +40,13 @@
  * @brief Defines the max number of contexts to be allocated (excluding predefined).
  */
 #define MPI_CONTEXTS_ALLOCATE_MAX 0
+
+/**
+ * @brief Defines the available communication modes for pt2pt communication.
+ */
+#define COMM_READY_MODE    0
+#define COMM_BUFFERED_MODE 1
+#define COMM_SYNC_MODE     2
 
 /**
  * @brief Struct that defines a basic communication context.
@@ -65,7 +74,7 @@ extern int comm_context_allocate(void);
  * @brief Initializes the contexts submodule.
  *
  * @returns Upon successful completion, zero is returned. A
- * negative MPI error code is returned instead.
+ * negative error code is returned instead.
  */
 extern int comm_context_init(void);
 
@@ -76,5 +85,19 @@ extern int comm_context_init(void);
  * negative error code is returned instead.
  */
 extern int comm_context_finalize(void);
+
+/*============================================================================*
+ * Comm Operations.                                                           *
+ *============================================================================*/
+
+/**
+ * @todo Provide a detailed description.
+ */
+extern int send(int cid, const void *buf, size_t size, mpi_process_t *dest, int datatype, int tag, int mode);
+
+/**
+ * @todo Provide a detailed description.
+ */
+extern int recv(int cid, void *buf, size_t size, mpi_process_t *src, int datatype, struct comm_request *req);
 
 #endif /* NANVIX_COMM_CONTEXT_H_ */

--- a/include/mputil/comm_request.h
+++ b/include/mputil/comm_request.h
@@ -1,0 +1,93 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_COMM_REQUEST_H_
+#define NANVIX_COMM_REQUEST_H_
+
+/**
+ * @brief Struct that defines a basic communication request.
+ */
+struct comm_request
+{
+	int cid;           /* Request context. */
+	int src;           /* Source.          */
+	int tag;           /* Message tag.     */
+	int received_size; /* Received size.   */
+};
+
+/**
+ * @brief Builds a new communication requisition.
+ *
+ * @param cid Request context.
+ * @param src Request src.
+ * @param tag Request tag.
+ * @param req Request reference to be initialized.
+ *
+ * @todo Add a hash function to make requests comparation quicker.
+ */
+extern void comm_request_build(int cid, int src, int tag, struct comm_request *req);
+
+/**
+ * @brief Allocates a new request and registers it in the requisitions queue.
+ *
+ * @param req Requisition to be registered.
+ *
+ * @returns Upon successful completion, zero is returned. Upon failure, a negative
+ * error code is returned instead.
+ *
+ * @todo Implement this function.
+ *
+ * @note This function needs to copy the req attributes in a safe structure, not only
+ * storing its reference.
+ */
+extern int comm_request_register(struct comm_request *req);
+
+/**
+ * @brief Compares if two communication requisitions are equal.
+ *
+ * @param req1 First requisition to be compared.
+ * @param req2 Second requisition.
+ *
+ * @returns Returns ZERO if the requisitions are different and a NON-ZERO value if
+ * they match correctly.
+ */
+extern int comm_request_match(struct comm_request *req1, struct comm_request *req2);
+
+/**
+ * @brief Initializes the requests submodule.
+ *
+ * @returns Upon successful completion, zero is returned. A
+ * negative MPI error code is returned instead.
+ */
+extern int comm_request_init(void);
+
+/**
+ * @brief Finalizes the requests submodule.
+ *
+ * @returns Upon successful completion, zero is returned. A
+ * negative error code is returned instead.
+ */
+extern int comm_request_finalize(void);
+
+#endif /* NANVIX_COMM_REQUEST_H_ */

--- a/include/mputil/proc.h
+++ b/include/mputil/proc.h
@@ -56,6 +56,18 @@ typedef struct mpi_process_t mpi_process_t;
 OBJ_CLASS_DECLARATION(mpi_process_t);
 
 /**
+ * @brief Gets the process name.
+ *
+ * @param proc Target process.
+ *
+ * @returns The process symbolic name.
+ */
+static inline const char * process_name(mpi_process_t *proc)
+{
+	return (proc->name);
+}
+
+/**
  * @brief Allocates a new process for @p nodeid.
  *
  * @returns Upon successful completion, PID of the new

--- a/src/mpi/communicator/comm_get_errhandler.c
+++ b/src/mpi/communicator/comm_get_errhandler.c
@@ -43,7 +43,7 @@ PUBLIC int MPI_Comm_get_errhandler(MPI_Comm comm, MPI_Errhandler *errhandler)
 	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
 
 	/* Bad communicator. */
-	if ((comm == NULL) || (comm == MPI_COMM_NULL))
+	if (!mpi_comm_is_valid(comm))
 		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME));
 
 	/* Bad errhandler holder. */

--- a/src/mpi/communicator/comm_group.c
+++ b/src/mpi/communicator/comm_group.c
@@ -45,7 +45,7 @@ PUBLIC int MPI_Comm_group(MPI_Comm comm, MPI_Group *group)
 	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
 
 	/* Bad communicator. */
-	if ((comm == NULL) || (comm == MPI_COMM_NULL))
+	if (!mpi_comm_is_valid(comm))
 		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME));
 
 	/* Bad group holder. */

--- a/src/mpi/communicator/comm_rank.c
+++ b/src/mpi/communicator/comm_rank.c
@@ -43,7 +43,7 @@ PUBLIC int MPI_Comm_rank(MPI_Comm comm, int *rank)
 	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
 
 	/* Bad communicator. */
-	if ((comm == NULL) || (comm == MPI_COMM_NULL))
+	if (!mpi_comm_is_valid(comm))
 		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME));
 
 	/* Bad rank holder. */

--- a/src/mpi/communicator/comm_set_errhandler.c
+++ b/src/mpi/communicator/comm_set_errhandler.c
@@ -39,25 +39,31 @@ static const char FUNC_NAME[] = "MPI_Comm_set_errhandler";
  */
 PUBLIC int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
 {
+	int ret;
 	mpi_errhandler_t *tmp;
 
 	/* Parameters checking. */
 	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
 
 	/* Bad communicator. */
-	if ((comm == NULL) || (comm == MPI_COMM_NULL))
+	if (!mpi_comm_is_valid(comm))
 		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME));
 
+	ret = MPI_SUCCESS;
+
 	/* Bad errhandler reference. */
-	if ((errhandler == NULL) || (errhandler == MPI_ERRHANDLER_NULL))
-		goto error;
+	if (!mpi_errhandler_is_valid(errhandler))
+		ret = MPI_ERR_ARG;
 
 	/* Bad errhandler_type. */
 	if ((errhandler->errhandler_object_type != MPI_ERRHANDLER_TYPE_COMM) &&
 		(errhandler->errhandler_object_type != MPI_ERRHANDLER_TYPE_PREDEFINED))
 	{
-		goto error;
+		ret = MPI_ERR_ARG;
 	}
+
+	/* Checks if there was an error and calls an error handler case positive. */
+	MPI_ERRHANDLER_CHECK(ret, comm, ret, FUNC_NAME);
 
 	/* Associates the new error handler with @p comm. */
 	tmp = comm->error_handler;
@@ -68,7 +74,4 @@ PUBLIC int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
 	OBJ_RELEASE(tmp);
 
 	return (MPI_SUCCESS);
-
-error:
-	return (MPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME));
 }

--- a/src/mpi/communicator/comm_size.c
+++ b/src/mpi/communicator/comm_size.c
@@ -43,7 +43,7 @@ PUBLIC int MPI_Comm_size(MPI_Comm comm, int *size)
 	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
 
 	/* Bad communicator. */
-	if ((comm == NULL) || (comm == MPI_COMM_NULL))
+	if (!mpi_comm_is_valid(comm))
 		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME));
 
 	/* Bad size holder. */

--- a/src/mpi/communicator/communicator.c
+++ b/src/mpi/communicator/communicator.c
@@ -27,7 +27,7 @@
 #include <posix/errno.h>
 #include <mpi/communicator.h>
 #include <mpi/mpiruntime.h>
-#include <nanvix/limits.h>
+#include <mputil/comm_context.h>
 
 PRIVATE void mpi_comm_construct(mpi_communicator_t *);
 PRIVATE void mpi_comm_destruct(mpi_communicator_t *);
@@ -167,8 +167,8 @@ PUBLIC int mpi_comm_init(void)
 
 	_mpi_comm_world.group         = group;
 	_mpi_comm_world.my_rank       = group->my_rank;
-	_mpi_comm_world.pt2pt_cid     = 0;
-	_mpi_comm_world.coll_cid      = 1;
+	_mpi_comm_world.pt2pt_cid     = MPI_CONTEXT_BASE;
+	_mpi_comm_world.coll_cid      = (MPI_CONTEXT_BASE + 1);
 	_mpi_comm_world.error_handler = MPI_ERRORS_ARE_FATAL;
 	OBJ_RETAIN(_mpi_comm_world.error_handler);
 
@@ -184,7 +184,7 @@ PUBLIC int mpi_comm_init(void)
 
 	_mpi_comm_self.group         = group;
 	_mpi_comm_self.my_rank       = group->my_rank;
-	_mpi_comm_self.pt2pt_cid     = 2;
+	_mpi_comm_self.pt2pt_cid     = (MPI_CONTEXT_BASE + 2);
 	_mpi_comm_self.coll_cid      = MPI_UNDEFINED;
 	_mpi_comm_self.error_handler = MPI_ERRORS_ARE_FATAL;
 	OBJ_RETAIN(_mpi_comm_self.error_handler);

--- a/src/mpi/communicator/communicator.c
+++ b/src/mpi/communicator/communicator.c
@@ -146,6 +146,31 @@ PUBLIC int mpi_comm_group(mpi_communicator_t *comm, mpi_group_t **group)
 }
 
 /**
+ * @todo Provide a detailed description.
+ */
+PUBLIC int mpi_comm_get_proc(mpi_communicator_t *comm, int rank, mpi_process_t **proc)
+{
+	int ret;
+
+	/* Bad communicator. */
+	if (comm == NULL)
+		return (MPI_ERR_COMM);
+
+	/* Bad proc receptor. */
+	if (proc == NULL)
+		return (MPI_ERR_ARG);
+
+	/* Invalid rank. */
+	if (!mpi_comm_peer_rank_is_valid(comm, rank))
+		return (MPI_ERR_RANK);
+
+	/* Gets the proc reference from within comm group. */
+	ret = mpi_group_get_proc(comm->group, rank, proc);
+
+	return (ret);
+}
+
+/**
  * @see mpi_comm_init() at communicator.h.
  *
  * @todo See necessity of defining a communicators array.
@@ -167,8 +192,8 @@ PUBLIC int mpi_comm_init(void)
 
 	_mpi_comm_world.group         = group;
 	_mpi_comm_world.my_rank       = group->my_rank;
-	_mpi_comm_world.pt2pt_cid     = MPI_CONTEXT_BASE;
-	_mpi_comm_world.coll_cid      = (MPI_CONTEXT_BASE + 1);
+	_mpi_comm_world.pt2pt_cid     = 0;
+	_mpi_comm_world.coll_cid      = 1;
 	_mpi_comm_world.error_handler = MPI_ERRORS_ARE_FATAL;
 	OBJ_RETAIN(_mpi_comm_world.error_handler);
 
@@ -184,7 +209,7 @@ PUBLIC int mpi_comm_init(void)
 
 	_mpi_comm_self.group         = group;
 	_mpi_comm_self.my_rank       = group->my_rank;
-	_mpi_comm_self.pt2pt_cid     = (MPI_CONTEXT_BASE + 2);
+	_mpi_comm_self.pt2pt_cid     = 2;
 	_mpi_comm_self.coll_cid      = MPI_UNDEFINED;
 	_mpi_comm_self.error_handler = MPI_ERRORS_ARE_FATAL;
 	OBJ_RETAIN(_mpi_comm_self.error_handler);

--- a/src/mpi/datatype/datatype.c
+++ b/src/mpi/datatype/datatype.c
@@ -36,38 +36,38 @@ OBJ_CLASS_INSTANCE(mpi_datatype_t, &mpi_datatype_construct,
 /**
  * @brief Predefined datatypes.
  */
-const mpi_datatype_t _mpi_datatype_char                = MPI_DATATYPE_INITIALIZER_CHAR;
-const mpi_datatype_t _mpi_datatype_short               = MPI_DATATYPE_INITIALIZER_SHORT;
-const mpi_datatype_t _mpi_datatype_int                 = MPI_DATATYPE_INITIALIZER_INT;
-const mpi_datatype_t _mpi_datatype_long                = MPI_DATATYPE_INITIALIZER_LONG;
-const mpi_datatype_t _mpi_datatype_long_long           = MPI_DATATYPE_INITIALIZER_LONG_LONG;
-const mpi_datatype_t _mpi_datatype_signed_char         = MPI_DATATYPE_INITIALIZER_SIGNED_CHAR;
-const mpi_datatype_t _mpi_datatype_unsigned_char       = MPI_DATATYPE_INITIALIZER_UNSIGNED_CHAR;
-const mpi_datatype_t _mpi_datatype_unsigned_short      = MPI_DATATYPE_INITIALIZER_UNSIGNED_SHORT;
-const mpi_datatype_t _mpi_datatype_unsigned            = MPI_DATATYPE_INITIALIZER_UNSIGNED;
-const mpi_datatype_t _mpi_datatype_unsigned_long       = MPI_DATATYPE_INITIALIZER_UNSIGNED_LONG;
-const mpi_datatype_t _mpi_datatype_unsigned_long_long  = MPI_DATATYPE_INITIALIZER_UNSIGNED_LONG_LONG;
-const mpi_datatype_t _mpi_datatype_float               = MPI_DATATYPE_INITIALIZER_FLOAT;
-const mpi_datatype_t _mpi_datatype_double              = MPI_DATATYPE_INITIALIZER_DOUBLE;
-const mpi_datatype_t _mpi_datatype_long_double         = MPI_DATATYPE_INITIALIZER_LONG_DOUBLE;
-const mpi_datatype_t _mpi_datatype_wchar               = MPI_DATATYPE_INITIALIZER_WCHAR;
-const mpi_datatype_t _mpi_datatype_cbool               = MPI_DATATYPE_INITIALIZER_C_BOOL;
-const mpi_datatype_t _mpi_datatype_int8                = MPI_DATATYPE_INITIALIZER_INT8;
-const mpi_datatype_t _mpi_datatype_int16               = MPI_DATATYPE_INITIALIZER_INT16;
-const mpi_datatype_t _mpi_datatype_int32               = MPI_DATATYPE_INITIALIZER_INT32;
-const mpi_datatype_t _mpi_datatype_int64               = MPI_DATATYPE_INITIALIZER_INT64;
-const mpi_datatype_t _mpi_datatype_uint8               = MPI_DATATYPE_INITIALIZER_UINT8;
-const mpi_datatype_t _mpi_datatype_uint16              = MPI_DATATYPE_INITIALIZER_UINT16;
-const mpi_datatype_t _mpi_datatype_uint32              = MPI_DATATYPE_INITIALIZER_UINT32;
-const mpi_datatype_t _mpi_datatype_uint64              = MPI_DATATYPE_INITIALIZER_UINT64;
-const mpi_datatype_t _mpi_datatype_ccomplex            = MPI_DATATYPE_INITIALIZER_C_COMPLEX;
-const mpi_datatype_t _mpi_datatype_double_complex      = MPI_DATATYPE_INITIALIZER_C_DOUBLE_COMPLEX;
-const mpi_datatype_t _mpi_datatype_long_double_complex = MPI_DATATYPE_INITIALIZER_C_LONG_DOUBLE_COMPLEX;
-const mpi_datatype_t _mpi_datatype_byte                = MPI_DATATYPE_INITIALIZER_BYTE;
-const mpi_datatype_t _mpi_datatype_packed              = MPI_DATATYPE_INITIALIZER_PACKED;
-const mpi_datatype_t _mpi_datatype_aint                = MPI_DATATYPE_INITIALIZER_AINT;
-const mpi_datatype_t _mpi_datatype_offset              = MPI_DATATYPE_INITIALIZER_OFFSET;
-const mpi_datatype_t _mpi_datatype_count               = MPI_DATATYPE_INITIALIZER_COUNT;
+mpi_datatype_t _mpi_datatype_char                = MPI_DATATYPE_INITIALIZER_CHAR;
+mpi_datatype_t _mpi_datatype_short               = MPI_DATATYPE_INITIALIZER_SHORT;
+mpi_datatype_t _mpi_datatype_int                 = MPI_DATATYPE_INITIALIZER_INT;
+mpi_datatype_t _mpi_datatype_long                = MPI_DATATYPE_INITIALIZER_LONG;
+mpi_datatype_t _mpi_datatype_long_long           = MPI_DATATYPE_INITIALIZER_LONG_LONG;
+mpi_datatype_t _mpi_datatype_signed_char         = MPI_DATATYPE_INITIALIZER_SIGNED_CHAR;
+mpi_datatype_t _mpi_datatype_unsigned_char       = MPI_DATATYPE_INITIALIZER_UNSIGNED_CHAR;
+mpi_datatype_t _mpi_datatype_unsigned_short      = MPI_DATATYPE_INITIALIZER_UNSIGNED_SHORT;
+mpi_datatype_t _mpi_datatype_unsigned            = MPI_DATATYPE_INITIALIZER_UNSIGNED;
+mpi_datatype_t _mpi_datatype_unsigned_long       = MPI_DATATYPE_INITIALIZER_UNSIGNED_LONG;
+mpi_datatype_t _mpi_datatype_unsigned_long_long  = MPI_DATATYPE_INITIALIZER_UNSIGNED_LONG_LONG;
+mpi_datatype_t _mpi_datatype_float               = MPI_DATATYPE_INITIALIZER_FLOAT;
+mpi_datatype_t _mpi_datatype_double              = MPI_DATATYPE_INITIALIZER_DOUBLE;
+mpi_datatype_t _mpi_datatype_long_double         = MPI_DATATYPE_INITIALIZER_LONG_DOUBLE;
+mpi_datatype_t _mpi_datatype_wchar               = MPI_DATATYPE_INITIALIZER_WCHAR;
+mpi_datatype_t _mpi_datatype_cbool               = MPI_DATATYPE_INITIALIZER_C_BOOL;
+mpi_datatype_t _mpi_datatype_int8                = MPI_DATATYPE_INITIALIZER_INT8;
+mpi_datatype_t _mpi_datatype_int16               = MPI_DATATYPE_INITIALIZER_INT16;
+mpi_datatype_t _mpi_datatype_int32               = MPI_DATATYPE_INITIALIZER_INT32;
+mpi_datatype_t _mpi_datatype_int64               = MPI_DATATYPE_INITIALIZER_INT64;
+mpi_datatype_t _mpi_datatype_uint8               = MPI_DATATYPE_INITIALIZER_UINT8;
+mpi_datatype_t _mpi_datatype_uint16              = MPI_DATATYPE_INITIALIZER_UINT16;
+mpi_datatype_t _mpi_datatype_uint32              = MPI_DATATYPE_INITIALIZER_UINT32;
+mpi_datatype_t _mpi_datatype_uint64              = MPI_DATATYPE_INITIALIZER_UINT64;
+mpi_datatype_t _mpi_datatype_ccomplex            = MPI_DATATYPE_INITIALIZER_C_COMPLEX;
+mpi_datatype_t _mpi_datatype_double_complex      = MPI_DATATYPE_INITIALIZER_C_DOUBLE_COMPLEX;
+mpi_datatype_t _mpi_datatype_long_double_complex = MPI_DATATYPE_INITIALIZER_C_LONG_DOUBLE_COMPLEX;
+mpi_datatype_t _mpi_datatype_byte                = MPI_DATATYPE_INITIALIZER_BYTE;
+mpi_datatype_t _mpi_datatype_packed              = MPI_DATATYPE_INITIALIZER_PACKED;
+mpi_datatype_t _mpi_datatype_aint                = MPI_DATATYPE_INITIALIZER_AINT;
+mpi_datatype_t _mpi_datatype_offset              = MPI_DATATYPE_INITIALIZER_OFFSET;
+mpi_datatype_t _mpi_datatype_count               = MPI_DATATYPE_INITIALIZER_COUNT;
 
 /**
  * @brief Null datatype.
@@ -131,6 +131,28 @@ PRIVATE void mpi_datatype_construct(mpi_datatype_t * datatype)
 PRIVATE void mpi_datatype_destruct(mpi_datatype_t * datatype)
 {
 	uassert(datatype != NULL);
+}
+
+/**
+ * @brief Provide a detailed description.
+ *
+ * @note This dummy implementation assumes that only the
+ * predefined datatypes are available to be used.
+ */
+PUBLIC int mpi_datatypes_match(int type1, int type2)
+{
+	uassert(WITHIN(type1, 0, MPI_DATATYPE_MAX_PREDEFINED));
+	uassert(WITHIN(type2, 0, MPI_DATATYPE_MAX_PREDEFINED));
+
+	/* Same datatype. */
+	if (type1 == type2)
+		return (1);
+
+	/* One of they is MPI_BYTE. */
+	if ((type1 == MPI_DATATYPE_BYTE) || (type2 == MPI_DATATYPE_BYTE))
+		return (1);
+
+	return (0);
 }
 
 /**

--- a/src/mpi/errhandler/errhandler_free.c
+++ b/src/mpi/errhandler/errhandler_free.c
@@ -43,8 +43,10 @@ PUBLIC int MPI_Errhandler_free(MPI_Errhandler *errhandler)
 	/* Parameters checking. */
 	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
 
+	if (!mpi_errhandler_is_valid(*errhandler))
+
 	/* Bad error handler. */
-	if ((errhandler == NULL) || (*errhandler == NULL) || (*errhandler == MPI_ERRHANDLER_NULL))
+	if ((errhandler == NULL) || (!mpi_errhandler_is_valid(*errhandler)))
 		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME));
 
 	ret = mpi_errhandler_free((mpi_errhandler_t **) errhandler);

--- a/src/mpi/group/group.c
+++ b/src/mpi/group/group.c
@@ -232,6 +232,29 @@ PUBLIC void mpi_group_set_rank(mpi_group_t * group, mpi_process_t * proc)
 }
 
 /**
+ * @todo Provide a detailed description.
+ */
+PUBLIC int mpi_group_get_proc(mpi_group_t *group, int rank, mpi_process_t **proc)
+{
+	/* Bad group. */
+	if (group == NULL)
+		return (MPI_ERR_GROUP);
+
+	/* Bad pointer. */
+	if (proc == NULL)
+		return (MPI_ERR_ARG);
+
+	/* Bad rank. */
+	if (!WITHIN(rank, 0, group->size))
+		return (MPI_ERR_RANK);
+
+	/* Gets the proc reference. */
+	*proc = group->procs[rank];
+
+	return (MPI_SUCCESS);
+}
+
+/**
  * @brief Initializes the groups submodule.
  *
  * @returns Upon successful completion, zero is returned. A

--- a/src/mpi/group/group_free.c
+++ b/src/mpi/group/group_free.c
@@ -45,7 +45,7 @@ PUBLIC int MPI_Group_free(MPI_Group *group)
 	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
 
 	/* Bad group. */
-	if ((group == NULL) || (*group == NULL) || (*group == MPI_GROUP_NULL))
+	if ((group == NULL) || (!mpi_group_is_valid(*group)))
 		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_GROUP, FUNC_NAME));
 
 	ret = mpi_group_free((mpi_group_t **) group);

--- a/src/mpi/group/group_rank.c
+++ b/src/mpi/group/group_rank.c
@@ -43,16 +43,23 @@ static const char FUNC_NAME[] = "MPI_Group_rank";
  */
 PUBLIC int MPI_Group_rank(MPI_Group group, int *rank)
 {
+	int ret;
+
 	/* Parameters checking. */
 	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
 
+	ret = MPI_SUCCESS;
+
 	/* Bad group. */
-	if ((group == NULL) || (group == MPI_GROUP_NULL))
-		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_GROUP, FUNC_NAME));
+	if (!mpi_group_is_valid(group))
+		ret = MPI_ERR_GROUP;
 
 	/* Bad rank holder. */
 	if (rank == NULL)
-		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME));
+		ret = MPI_ERR_ARG;
+
+	/* Checks if there was an error and calls an error handler case positive. */
+	MPI_ERRHANDLER_CHECK(ret, MPI_COMM_WORLD, ret, FUNC_NAME);
 
 	*rank = mpi_group_rank((mpi_group_t *) group);
 

--- a/src/mpi/group/group_size.c
+++ b/src/mpi/group/group_size.c
@@ -40,16 +40,23 @@ static const char FUNC_NAME[] = "MPI_Group_size";
  */
 PUBLIC int MPI_Group_size(MPI_Group group, int *size)
 {
+	int ret;
+
 	/* Parameters checking. */
 	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
 
+	ret = MPI_SUCCESS;
+
 	/* Bad group. */
-	if ((group == NULL) || (group == MPI_GROUP_NULL))
-		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_GROUP, FUNC_NAME));
+	if (!mpi_group_is_valid(group))
+		ret = MPI_ERR_GROUP;
 
 	/* Bad size holder. */
 	if (size == NULL)
-		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME));
+		ret = MPI_ERR_ARG;
+
+	/* Checks if there was an error and calls an error handler case positive. */
+	MPI_ERRHANDLER_CHECK(ret, MPI_COMM_WORLD, ret, FUNC_NAME);
 
 	*size = mpi_group_size((mpi_group_t *) group);
 

--- a/src/mpi/makefile
+++ b/src/mpi/makefile
@@ -34,7 +34,8 @@ SRC = $(wildcard group/*.c)        \
       $(wildcard communicator/*.c) \
       $(wildcard errhandler/*.c)   \
       $(wildcard runtime/*.c)      \
-      $(wildcard datatype/*.c)
+      $(wildcard datatype/*.c)     \
+      $(wildcard pt2pt/*.c)
 
 OBJ = $(SRC:.c=.$(OBJ_SUFFIX).o)
 

--- a/src/mpi/pt2pt/pt2pt_comm.c
+++ b/src/mpi/pt2pt/pt2pt_comm.c
@@ -1,0 +1,108 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/runtime/pm.h>
+#include <mputil/comm_context.h>
+#include <mputil/comm_request.h>
+#include <mpi/pt2pt_comm.h>
+#include <mpi/communicator.h>
+#include <mpi/datatype.h>
+
+/**
+ * @brief Provide detailed description.
+ */
+PUBLIC int mpi_send(const void *buf, int count, MPI_Datatype datatype, int dest,
+	                int tag, MPI_Comm comm, mpi_comm_mode_t mode)
+{
+	int ret;
+	int cid;
+	size_t size;
+	int datatype_id;
+	mpi_process_t *dest_proc;
+
+	/* Gets the communicator context ID. */
+	cid = mpi_comm_get_pt2pt_cid(comm);
+
+	/* Calculates the send total size. */
+	size = count * mpi_datatype_size(datatype);
+
+	/* Gets the target process based in dest rank. */
+	if ((ret = mpi_comm_get_proc(comm, dest, &dest_proc)) != MPI_SUCCESS)
+		return (ret);
+
+	/* Gets the datatype id. */
+	datatype_id = mpi_datatype_id(datatype);
+
+	ret = send(cid, buf, size, dest_proc, datatype_id, tag, mode);
+
+	return (ret);
+}
+
+/**
+ * @brief Provide detailed description.
+ */
+PUBLIC int mpi_recv(void *buf, int count, MPI_Datatype datatype, int source,
+	                int tag, MPI_Comm comm, MPI_Status *status)
+{
+	int ret;
+	int cid;
+	size_t size;
+	int datatype_id;
+	int src_nodenum;
+	mpi_process_t *src_proc;
+	struct comm_request request;
+
+	/* Gets the communicator context ID. */
+	cid = mpi_comm_get_pt2pt_cid(comm);
+
+	/* Calculates the send total size. */
+	size = count * mpi_datatype_size(datatype);
+
+	/* Gets the target process based in source rank. */
+	if ((ret = mpi_comm_get_proc(comm, source, &src_proc)) != MPI_SUCCESS)
+		return (ret);
+
+	/* Gets the datatype id. */
+	datatype_id = mpi_datatype_id(datatype);
+
+	/* Lookup for the source nodenum. */
+	if ((src_nodenum = nanvix_name_lookup(process_name(src_proc))) < 0)
+		return (MPI_ERR_UNKNOWN);
+
+	/* Builds the recv request to be compared in the underlying function. */
+	request.cid = cid;
+	request.src = src_nodenum;
+	request.tag = tag;
+
+	ret = recv(cid, buf, size, src_proc, datatype_id, &request);
+
+	/* Updates the STATUS. */
+	if (status != MPI_STATUS_IGNORE)
+	{
+		status->MPI_ERROR     = ret;
+		status->received_size = request.received_size;
+	}
+
+	return (ret);
+}

--- a/src/mpi/pt2pt/recv.c
+++ b/src/mpi/pt2pt/recv.c
@@ -1,0 +1,112 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <mpi/pt2pt_comm.h>
+#include <mpi/communicator.h>
+#include <mpi/datatype.h>
+#include <mpi.h>
+
+static const char FUNC_NAME[] = "MPI_Recv";
+
+/**
+ * @brief Receives a message from a target process inside @p comm context.
+ *
+ * @param buf      Data buffer to be sent.
+ * @param count    Number of @p datatype entries to in @p buf.
+ * @param datatype Type of data to be transfered.
+ * @param source   Source process rank.
+ * @param tag      Message identifier.
+ * @param comm     Communicator that defines the context of communication.
+ * @param status   Status variable to hold extra information about the communication.
+ *
+ * @returns Upon successful completion, MPI_SUCCESS is returned. An MPI errorcode
+ * is returned instead.
+ */
+PUBLIC int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status)
+{
+	int ret; /* Function return. */
+
+	/* Parameters checking. */
+	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
+
+	/* Bad communicator. */
+	if (!mpi_comm_is_valid(comm))
+		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME));
+
+	ret = MPI_SUCCESS;
+
+	/* Bad count. */
+	if (count < 0)
+		ret = MPI_ERR_COUNT;
+
+	/* Bad tag. */
+	if (!WITHIN(tag, 0, UB) && (tag != MPI_ANY_TAG))
+		ret = MPI_ERR_TAG;
+
+	/* Bad buffer. */
+	if ((buf == NULL) && (count > 0))
+		ret = MPI_ERR_BUFFER;
+
+	/* Bad datatype. */
+	if (!mpi_datatype_is_valid(datatype))
+		ret = MPI_ERR_TYPE;
+
+	/**
+	 * @note MPI_Status == NULL means MPI_STATUS_IGNORE, and so this parameter
+	 * doesn't need to be verified.
+	 */
+
+	/* Bad source. */
+	if ((source != MPI_PROC_NULL) && (source != MPI_ANY_SOURCE) && (!mpi_comm_peer_rank_is_valid(comm, source)))
+		ret = MPI_ERR_RANK;
+
+	/* Checks if there was an error and calls an error handler case positive. */
+	MPI_ERRHANDLER_CHECK(ret, comm, ret, FUNC_NAME);
+
+	/* Initializes status variable. */
+	if (status != MPI_STATUS_IGNORE)
+	{
+		status->MPI_SOURCE = source;
+		status->MPI_TAG    = tag;
+	}
+
+	/* Null recv. */
+	if (source == MPI_PROC_NULL)
+	{
+		if (status != MPI_STATUS_IGNORE)
+		{
+			status->MPI_ERROR     = MPI_SUCCESS;
+			status->received_size = 0;
+		}
+
+		return (MPI_SUCCESS);
+	}
+
+	ret = mpi_recv(buf, count, datatype, source, tag, comm, status);
+
+	/* Checks if the send op was successful. */
+	MPI_ERRHANDLER_CHECK(ret, comm, ret, FUNC_NAME);	
+
+	return (MPI_SUCCESS);
+}

--- a/src/mpi/pt2pt/send.c
+++ b/src/mpi/pt2pt/send.c
@@ -1,0 +1,97 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <mpi/pt2pt_comm.h>
+#include <mpi/communicator.h>
+#include <mpi/datatype.h>
+#include <mpi.h>
+
+static const char FUNC_NAME[] = "MPI_Send";
+
+/**
+ * @brief Sends a message to a target process inside @p comm context.
+ *
+ * @param buf      Data buffer to be sent.
+ * @param count    Number of @p datatype entries to in @p buf.
+ * @param datatype Type of data to be transfered.
+ * @param dest     Target process rank.
+ * @param tag      Message identifier.
+ * @param comm     Communicator that defines the context of communication.
+ *
+ * @returns Upon successful completion, MPI_SUCCESS is returned. An MPI errorcode
+ * is returned instead.
+ */
+PUBLIC int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm)
+{
+	int ret;              /* Function return. */
+	mpi_comm_mode_t mode; /* Send mode.       */
+
+	/* Parameters checking. */
+	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
+
+	/* Bad communicator. */
+	if (!mpi_comm_is_valid(comm))
+		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME));
+
+	ret = MPI_SUCCESS;
+
+	/* Bad count. */
+	if (count < 0)
+		ret = MPI_ERR_COUNT;
+
+	/* Bad tag. */
+	if (!WITHIN(tag, 0, UB))
+		ret = MPI_ERR_TAG;
+
+	/* Bad buffer. */
+	if ((buf == NULL) && (count > 0))
+		ret = MPI_ERR_BUFFER;
+
+	/* Bad datatype. */
+	if (!mpi_datatype_is_valid(datatype))
+		ret = MPI_ERR_TYPE;
+
+	/* Bad dest. */
+	if ((dest != MPI_PROC_NULL) && (!mpi_comm_peer_rank_is_valid(comm, dest)))
+		ret = MPI_ERR_RANK;
+
+	/* Checks if there was an error and calls an error handler case positive. */
+	MPI_ERRHANDLER_CHECK(ret, comm, ret, FUNC_NAME);
+
+	/* Null send. */
+	if (dest == MPI_PROC_NULL)
+		return (MPI_SUCCESS);
+
+	/**
+	 * @todo Add logic to choose the best send mode here.
+	 */
+	mode = SYNC_MODE;
+
+	ret = mpi_send(buf, count, datatype, dest, tag, comm, mode);
+
+	/* Checks if the send op was successful. */
+	MPI_ERRHANDLER_CHECK(ret, comm, ret, FUNC_NAME);	
+
+	return (MPI_SUCCESS);
+}

--- a/src/mpi/runtime/runtime.c
+++ b/src/mpi/runtime/runtime.c
@@ -22,8 +22,8 @@
  * SOFTWARE.
  */
 
-#include <nanvix/hal.h>
 #include <mputil/proc.h>
+#include <mputil/comm_context.h>
 #include <mpi/mpiruntime.h>
 #include <mpi/errhandler.h>
 #include <mpi/group.h>
@@ -99,6 +99,13 @@ PUBLIC int mpi_init(int argc, char **argv)
 	if ((ret = mpi_group_init()) != MPI_SUCCESS)
 	{
 		uprintf("ERROR!!! mpi_group_init() failed");
+		goto end;
+	}
+
+	/* Initialize comm_contexts module. */
+	if ((ret = comm_context_init()) != MPI_SUCCESS)
+	{
+		uprintf("ERROR!!! comm_context_init() failed");
 		goto end;
 	}
 
@@ -185,6 +192,13 @@ PUBLIC int mpi_finalize(void)
 	if ((ret = mpi_comm_finalize()) != MPI_SUCCESS)
 	{
 		uprintf("ERROR!!! mpi_comm_finalize() failed");
+		goto end;
+	}
+
+	/* Finalize comm_contexts module. */
+	if ((ret = comm_context_finalize()) != MPI_SUCCESS)
+	{
+		uprintf("ERROR!!! comm_context_finalize() failed");
 		goto end;
 	}
 

--- a/src/mputil/comm_context.c
+++ b/src/mputil/comm_context.c
@@ -1,0 +1,126 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/ulib.h>
+#include <nanvix/runtime/pm.h>
+#include <mputil/comm_context.h>
+#include <mputil/proc.h>
+
+/**
+ * @brief Defines the number of predefined contexts.
+ *
+ * @note This is a standard definition related to the MPI Spec, and SHOULD NOT CHANGE.
+ */
+#define MPI_CONTEXTS_PREDEFINED 3
+
+/**
+ * @brief Total number of available contexts.
+ *
+ * @brief This is a convenience macro and only exists to avoid the manual sum. 
+ * IT SHOULD NEVER CHANGE.
+ */
+#define MPI_CONTEXTS_TOTAL (MPI_CONTEXTS_PREDEFINED + MPI_CONTEXTS_ALLOCATE_MAX)
+
+/**
+ * @brief Struct that defines a basic communication context.
+ */
+PRIVATE struct mpi_comm_context contexts[MPI_CONTEXTS_TOTAL] = {
+	[0 ... (MPI_CONTEXTS_TOTAL - 1)] = {
+		.port          = -1,
+		.inbox         = -1,
+		.inportal      = -1,
+		.is_collective =  0,
+	},
+};
+
+/**
+ * @see comm_context_allocate in comm_context.h.
+ *
+ * @todo Implement this function like described in the header file.
+ */
+PUBLIC int comm_context_allocate(void)
+{
+	return (0);
+}
+
+/**
+ * @see comm_context_init in comm_context.h.
+ */
+PUBLIC int comm_context_init(void)
+{
+	mpi_process_t *local_proc;
+	const char *local_name;
+
+	/* Runtime not initialized. */
+	if ((local_proc = process_local()) == NULL)
+		return (-EAGAIN);
+
+	local_name = local_proc->name;
+
+	/* Initializes the port number of each context. */
+	for (int i = 0; i < MPI_CONTEXTS_TOTAL; ++i)
+		contexts[i].port = (MPI_CONTEXT_BASE + i);
+
+	/* Initializes the MPI_COMM_WORLD contexts. */
+	for (int i = 0; i < MPI_CONTEXTS_PREDEFINED; ++i)
+	{
+		/* Initializes pt2pt context. */
+		if ((contexts[i].inbox = nanvix_mailbox_create2(local_name, contexts[i].port)) < 0)
+			return (-EAGAIN);
+
+		/* Initializes collective context. */
+		if ((contexts[i].inportal = nanvix_portal_create2(local_name, contexts[i].port)) < 0)
+			return (-EAGAIN);
+	}
+
+	/* Initializes the MPI_COMM_WORLD collective context. */
+	contexts[1].is_collective = 1;
+
+	return (0);
+}
+
+/**
+ * @see comm_context_finalize in comm_context.h.
+ */
+PUBLIC int comm_context_finalize(void)
+{
+	/* Unlinks the standard contexts inboxes/inportals. */
+	for (int i = 0; i < MPI_CONTEXTS_PREDEFINED; ++i)
+	{
+		if (nanvix_mailbox_unlink(contexts[i].inbox) < 0)
+			return (-EAGAIN);
+
+		if (nanvix_portal_unlink(contexts[i].inportal) < 0)
+			return (-EAGAIN);
+	}
+
+	/* Asserts that all allocated contexts were released. */
+	for (int i = MPI_CONTEXTS_PREDEFINED; i < MPI_CONTEXTS_TOTAL; ++i)
+	{
+		uassert(contexts[i].inbox == -1);
+		uassert(contexts[i].inportal == -1);
+	}
+
+	return (0);
+}

--- a/src/mputil/comm_context.c
+++ b/src/mputil/comm_context.c
@@ -25,7 +25,8 @@
 #include <nanvix/ulib.h>
 #include <nanvix/runtime/pm.h>
 #include <mputil/comm_context.h>
-#include <mputil/proc.h>
+#include <mpi/datatype.h>
+#include <mpi/mpi_errors.h>
 
 /**
  * @brief Defines the number of predefined contexts.
@@ -43,6 +44,31 @@
 #define MPI_CONTEXTS_TOTAL (MPI_CONTEXTS_PREDEFINED + MPI_CONTEXTS_ALLOCATE_MAX)
 
 /**
+ * @brief Struct that defines a message to establish communication.
+ */
+struct comm_message
+{
+	uint16_t cid;    /**< Message context. */
+	uint16_t source; /**< Source cluster.  */
+
+	union
+	{
+		struct
+		{
+			uint16_t datatype;   /**< Datatype.     */
+			size_t size;         /**< Message size. */
+			int32_t tag;         /**< Message tag.  */
+			uint8_t portal_port; /**< Port Number.  */
+		} send;
+
+		struct
+		{
+			int errcode; /* Function return. */
+		} ret;
+	} msg;
+};
+
+/**
  * @brief Struct that defines a basic communication context.
  */
 PRIVATE struct mpi_comm_context contexts[MPI_CONTEXTS_TOTAL] = {
@@ -53,6 +79,30 @@ PRIVATE struct mpi_comm_context contexts[MPI_CONTEXTS_TOTAL] = {
 		.is_collective =  0,
 	},
 };
+
+/*============================================================================*
+ * Message Operations.                                                        *
+ *============================================================================*/
+
+/**
+ * @todo Provide a detailed description.
+ */
+PRIVATE void request_header_build(struct comm_message *m, uint16_t cid, uint16_t type,
+	                              int size, uint32_t tag, uint8_t portal_port)
+{
+	uassert(m != NULL);
+
+	m->source               = knode_get_num();
+	m->cid                  = cid;
+	m->msg.send.datatype    = type;
+	m->msg.send.size        = size;
+	m->msg.send.tag         = tag;
+	m->msg.send.portal_port = portal_port;
+}
+
+/*============================================================================*
+ * Context Operations.                                                        *
+ *============================================================================*/
 
 /**
  * @see comm_context_allocate in comm_context.h.
@@ -123,4 +173,238 @@ PUBLIC int comm_context_finalize(void)
 	}
 
 	return (0);
+}
+
+/*============================================================================*
+ * Comm Operations.                                                           *
+ *============================================================================*/
+
+/*============================================================================*
+ * nanvix_send()                                                              *
+ *============================================================================*/
+
+/**
+ * @todo Provide a detailed description.
+ *
+ * @todo Implement this mode.
+ */
+
+PRIVATE int __rsend(int cid, const void *buf, size_t size, mpi_process_t *dest, int datatype, int tag)
+{
+	UNUSED(cid);
+	UNUSED(buf);
+	UNUSED(datatype);
+	UNUSED(size);
+	UNUSED(dest);
+	UNUSED(tag);
+
+	return (MPI_ERR_UNSUPPORTED_OPERATION);
+}
+
+/**
+ * @todo Provide a detailed description.
+ *
+ * @todo Implement this mode.
+ */
+PRIVATE int __bsend(int cid, const void *buf, size_t size, mpi_process_t *dest, int datatype, int tag)
+{
+	UNUSED(cid);
+	UNUSED(buf);
+	UNUSED(datatype);
+	UNUSED(size);
+	UNUSED(dest);
+	UNUSED(tag);
+
+	return (MPI_ERR_UNSUPPORTED_OPERATION);
+}
+
+/**
+ * @todo Provide a detailed description.
+ */
+PRIVATE int __ssend(int cid, const void *buf, size_t size, mpi_process_t *dest, int datatype, int tag)
+{
+	int ret;                     /**< Function return.              */
+	int outbox;                  /**< Mailbox used to send request. */
+	int outportal;               /**< Portal used to send data.     */
+	int port;                    /**< Outportal allocated port.     */
+	struct comm_message message; /**< Request message.              */
+	const char *name = process_name(dest);
+
+	ret = (MPI_ERR_UNKNOWN);
+
+	/* Opens the outbox to send the request. */
+	if ((outbox = nanvix_mailbox_open(name, contexts[cid].port)) < 0)
+		goto ret0;
+
+	/* Opens a new portal to send data. */
+	if ((outportal = nanvix_portal_open(name, contexts[cid].port)) < 0)
+		goto ret1;
+
+	port = nanvix_portal_get_port(outportal);
+
+	/* Constructs the message header. */
+	request_header_build(&message, cid, datatype, size, tag, port);
+
+	/* Sends a request to send to the receiver. */
+	if ((ret = nanvix_mailbox_write(outbox, (const void*) &message, sizeof(struct comm_message))) < 0)
+		goto ret2;
+
+	/* Sends the message to the receiver. */
+	if ((ret = nanvix_portal_write(outportal, buf, size)) < 0)
+		goto ret2;
+
+	/* Waits for recv ACK. */
+	if ((ret = nanvix_mailbox_read(contexts[cid].inbox, (void *) &message, sizeof(struct comm_message))) < 0)
+		goto ret2;
+
+	/* Confirms the ACK. */
+	ret = message.msg.ret.errcode;
+
+ret2:
+	/* Closes the outportal. */
+	if (nanvix_portal_close(outportal) < 0)
+		ret = (MPI_ERR_UNKNOWN);
+
+ret1:
+	/* Closes the outbox. */
+	if (nanvix_mailbox_close(outbox) < 0)
+		ret = (MPI_ERR_UNKNOWN);
+
+ret0:
+	return (ret);
+}
+
+PUBLIC int send(int cid, const void *buf, size_t size, mpi_process_t *dest, int datatype, int tag, int mode)
+{
+	int ret;
+
+	/* Bad context. */
+	if (!WITHIN(cid, 0, MPI_CONTEXTS_TOTAL))
+		return (MPI_ERR_INTERN);
+
+	/* Point-to-point context? */
+	if (contexts[cid].is_collective)
+		return (MPI_ERR_INTERN);
+
+	/* Mode selection. */
+	switch (mode)
+	{
+		case COMM_READY_MODE:
+			ret = __rsend(cid, buf, size, dest, datatype, tag);
+			break;
+
+		case COMM_BUFFERED_MODE:
+			ret = __bsend(cid, buf, size, dest, datatype, tag);
+			break;
+
+		case COMM_SYNC_MODE:
+			ret = __ssend(cid, buf, size, dest, datatype, tag);
+			break;
+
+		default:
+			/* Bad mode. */
+			ret = (MPI_ERR_ARG);
+	}
+
+	return (ret);
+}
+
+/*============================================================================*
+ * nanvix_recv()                                                              *
+ *============================================================================*/
+
+PRIVATE int __recv(int cid, void *buf, size_t size, mpi_process_t *src, int datatype, struct comm_request *req)
+{
+	int ret;
+	int overflow;
+	int outbox;                    /**< Output mailbox.       */
+	struct comm_message message;   /**< Received message.     */
+	struct comm_message reply;     /**< Requisition reply.    */
+	struct comm_request recvd_req; /**< Received requisition. */
+
+	/* Waits for a send request. */
+	if (nanvix_mailbox_read(contexts[cid].inbox, &message, sizeof(struct comm_message)) < 0)
+		return (MPI_ERR_UNKNOWN);
+
+	/* Builds a requisition based on the received comm_message. */
+	comm_request_build(message.cid, message.source, message.msg.send.tag, &recvd_req);
+
+	/* Checks if the expected and received requests match. */
+	if (!comm_request_match(req, &recvd_req))
+	{
+		/**
+		 * @todo Here we need to include logic to register the requests in a requesition queue
+		 * and go back to wait for a new one to arrive.
+		 */
+		return (MPI_ERR_INTERN);
+	}
+
+	/* Checks the other information that came in the message. */
+	if (!mpi_datatypes_match(datatype, message.msg.send.datatype))
+		return (MPI_ERR_TYPE);
+
+	/* Allows the remote to send data. */
+	if (nanvix_portal_allow2(contexts[cid].inportal, message.source, message.msg.send.portal_port) < 0)
+		return (MPI_ERR_INTERN);
+
+	overflow = 0;
+
+	/* Checks the amount of data to be received. */
+	if (size < message.msg.send.size)
+	{
+		req->received_size = size;
+		overflow = 1;
+	}
+	else
+		req->received_size = message.msg.send.size;
+
+	/* Receives data. */
+	if (nanvix_portal_read(contexts[cid].inportal, buf, req->received_size) < 0)
+	{
+		req->received_size = 0;
+		return (MPI_ERR_INTERN);
+	}
+
+	/* Opens a mailbox to send the ACK. */
+	if ((outbox = nanvix_mailbox_open(process_name(src), contexts[cid].port)) < 0)
+		return (MPI_ERR_UNKNOWN);
+
+	ret = MPI_SUCCESS;
+
+	if (overflow)
+		ret = MPI_ERR_OTHER;
+
+	/* Builds the return message. */
+	reply.cid = cid;
+	reply.source = knode_get_num();
+	reply.msg.ret.errcode = ret;
+
+	/* Sends an ACK message. */
+	if (nanvix_mailbox_write(outbox, (const void *) &reply, sizeof(struct comm_message)) < 0)
+		ret = MPI_ERR_INTERN;
+
+	uassert(nanvix_mailbox_close(outbox) == 0);
+
+	return (ret);
+}
+
+PUBLIC int recv(int cid, void *buf, size_t size, mpi_process_t *src, int datatype, struct comm_request *req)
+{
+	int ret;
+
+	/* Bad context. */
+	if (!WITHIN(cid, 0, MPI_CONTEXTS_TOTAL))
+		return (MPI_ERR_INTERN);
+
+	/* Point-to-point context? */
+	if (contexts[cid].is_collective)
+		return (MPI_ERR_INTERN);
+
+	/* Bad request holder. */
+	if (req == NULL)
+		return (MPI_ERR_INTERN);
+
+	ret = __recv(cid, buf, size, src, datatype, req);
+
+	return (ret);
 }

--- a/src/mputil/comm_request.c
+++ b/src/mputil/comm_request.c
@@ -1,0 +1,94 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/ulib.h>
+#include <mputil/comm_request.h>
+#include <mpi.h>
+
+/**
+ * @todo Provide a detailed description.
+ */
+PUBLIC void comm_request_build(int cid, int src, int tag, struct comm_request *req)
+{
+	uassert(req != NULL);
+
+	req->cid = cid;
+	req->src = src;
+	req->tag = tag;
+}
+
+/**
+ * @todo Provide a detailed description.
+ */
+PUBLIC int comm_request_match(struct comm_request *req1, struct comm_request *req2)
+{
+	uassert(req1 != NULL);
+	uassert(req2 != NULL);
+
+	/* Check cid. */
+	if (req1->cid != req2->cid)
+		return (0);
+
+	/* Check src. */
+	if ((req1->src != MPI_ANY_SOURCE) && (req2->src != MPI_ANY_SOURCE))
+	{
+		if (req1->src != req2->src)
+			return (0);
+	}
+
+	/* Check tag. */
+	if ((req1->tag != MPI_ANY_TAG) && (req2->tag != MPI_ANY_TAG))
+	{
+		if (req1->tag != req2->tag)
+			return (0);
+	}
+
+	return (1);
+}
+
+/**
+ * @todo Implement this function.
+ */
+PUBLIC int comm_request_register(struct comm_request *req)
+{
+	UNUSED(req);
+
+	return (0);
+}
+
+/**
+ * @todo Implement this function.
+ */
+PUBLIC int comm_request_init(void)
+{
+	return (0);
+}
+
+/**
+ * @todo Implement this function.
+ */
+PUBLIC int comm_request_finalize(void)
+{
+	return (0);
+}

--- a/src/mputil/proc.c
+++ b/src/mputil/proc.c
@@ -227,7 +227,7 @@ PUBLIC int mpi_proc_init(void)
 	uassert(_local_proc != NULL);
 
 	/* Register the local process in the system distributed lookup table. */
-	if ((ret = nanvix_setpname(_local_proc->name)) < 0)
+	if ((ret = nanvix_name_link(knode_get_num(), _local_proc->name)) < 0)
 		goto error;
 
 	return (0);


### PR DESCRIPTION
# Description #
In this PR we provide all the support necessary for Point-to-point communication and the `MPI_Send` and `MPI_Recv` functions in the `SYNCHRONOUS MODE`. At this point, the library supports communication in pairs, but doesn't handle out of order messages, failing in this situations. Besides the protocols of communication and the definition of communication contexts, this PR brings another small enhancements in the previous implemented interfaces, getting a much more stable version of this library.

# Related Issues #
- Closes #13 - [[mpi] Synchronous Point-to-point Communication](https://github.com/nanvix/libmpi/issues/13)