### PR TITLE
[runtime] Multiprocessed Clusters Environment

### DIFF
--- a/include/mpi/communicator.h
+++ b/include/mpi/communicator.h
@@ -25,7 +25,6 @@
 #ifndef NANVIX_MPI_COMMUNICATOR_H_
 #define NANVIX_MPI_COMMUNICATOR_H_
 
-#include <nanvix/hlib.h>
 #include <mputil/object.h>
 #include <mpi/group.h>
 #include <mpi/errhandler.h>

--- a/include/mpi/communicator.h
+++ b/include/mpi/communicator.h
@@ -38,7 +38,6 @@ struct mpi_communicator_t
 	object_t super;                        /* Base object class.             */
 
 	struct mpi_group_t *group;             /* Group associated with comm.    */
-	int my_rank;                           /* Local rank inside comm.        */
 	int pt2pt_cid;                         /* Point-to-point context ID.     */
 	int coll_cid;                          /* Collective context ID.         */
 
@@ -77,12 +76,14 @@ extern int mpi_comm_free(mpi_communicator_t **comm);
  * @brief Gets the local process rank in @p comm.
  *
  * @param comm Target communicator.
+ * @param rank Returned rank holder.
  *
- * @returns The local process rank in the communicator.
+ * @returns Upon successful completion, MPI_SUCESS is returned.
+ * Upon failure, a negative error code is returned instead.
  */
-static inline int mpi_comm_rank(mpi_communicator_t * comm)
+static inline int mpi_comm_rank(mpi_communicator_t * comm, int *rank)
 {
-    return (comm->my_rank);
+    return (mpi_group_rank(comm->group, rank));
 }
 
 /**

--- a/include/mpi/group.h
+++ b/include/mpi/group.h
@@ -36,7 +36,6 @@ struct mpi_group_t
 {
 	object_t super;               /* Base object class.        */
 
-	int my_rank;                  /* Local rank inside group.  */
 	struct mpi_process_t **procs; /* Pointer to procs list.    */
 	int size;                     /* Nr of processes in group. */
 	struct mpi_group_t *parent;   /* Parent group pointer.     */
@@ -107,23 +106,12 @@ static inline int mpi_group_size(mpi_group_t * group)
  * @brief Gets the local process rank inside the given group.
  *
  * @param group Group descriptor.
+ * @param rank  Returned rank holder.
  *
- * @returns The local process rank inside the group.
+ * @returns Upon successful completion, MPI_SUCESS is returned.
+ * Upon failure, a negative error code is returned instead.
  */
-static inline int mpi_group_rank(mpi_group_t * group)
-{
-	return group->my_rank;
-}
-
-/**
- * @brief Sets the local process rank inside the given group.
- *
- * @param group Group descriptor.
- * @param proc  Local process descriptor.
- *
- * @note A NULL pointer in @p proc will set the group rank to MPI_UNDEFINED.
- */
-extern void mpi_group_set_rank(mpi_group_t * group, mpi_process_t * proc);
+extern int mpi_group_rank(mpi_group_t * group, int *rank);
 
 /**
  * @brief Gets the proc associated with rank @p rank.

--- a/include/mpi/pt2pt_comm.h
+++ b/include/mpi/pt2pt_comm.h
@@ -31,7 +31,7 @@
  * @brief MPI Point-to-point communication modes.
  *
  * @note This enumeration should be in accord with the underlying constants
- * defined in mputil/comm_context.h whose defines the communication protocols
+ * defined in mputil/communication.h whose defines the communication protocols
  * available in the underlying levels.
  */
 typedef enum {

--- a/include/mputil/comm_context.h
+++ b/include/mputil/comm_context.h
@@ -30,16 +30,9 @@
 #include <mputil/comm_request.h>
 
 /**
- * @brief Defines the first context ID available for MPI communicators.
- *
- * @note Constant defined in nanvix/limits/pm.h.
+ * @brief Defines the limit for the context ID.
  */
-#define MPI_CONTEXT_BASE NANVIX_GENERAL_PORTS_BASE
-
-/**
- * @brief Defines the max number of contexts to be allocated (excluding predefined).
- */
-#define MPI_CONTEXTS_ALLOCATE_MAX 0
+#define MPI_CONTEXT_LIMIT 32768
 
 /**
  * @brief Defines the available communication modes for pt2pt communication.
@@ -47,17 +40,6 @@
 #define COMM_READY_MODE    0
 #define COMM_BUFFERED_MODE 1
 #define COMM_SYNC_MODE     2
-
-/**
- * @brief Struct that defines a basic communication context.
- */
-struct mpi_comm_context
-{
-	int port;              /* Context port number. */
-	int inbox;             /* Inbox ID.            */
-	int inportal;          /* Inportal ID.         */
-	uint8_t is_collective; /* Collective context?  */
-};
 
 /**
  * @brief Allocates a context and propagates it through the other processes.

--- a/include/mputil/comm_request.h
+++ b/include/mputil/comm_request.h
@@ -26,14 +26,20 @@
 #define NANVIX_COMM_REQUEST_H_
 
 /**
+ * @brief Predefined port number that is used to receive communication requests.
+ */
+#define COMM_REQ_RECV_PORT 15
+
+/**
  * @brief Struct that defines a basic communication request.
  */
 struct comm_request
 {
-	int16_t cid;           /* Request context. */
-	int16_t src;           /* Source.          */
-	int32_t tag;           /* Message tag.     */
-	int32_t received_size; /* Received size.   */
+	int16_t cid;           /**< Request context. */
+	int16_t src;           /**< Source rank.     */
+	int16_t target;        /**< Target rank.     */
+	int32_t tag;           /**< Message tag.     */
+	int32_t received_size; /**< Received size.   */
 };
 
 /**
@@ -59,7 +65,7 @@ struct comm_message
 
 		struct
 		{
-			int errcode; /* Function return. */
+			int errcode; /**< Function return. */
 		} ret;
 	} msg;
 };
@@ -67,29 +73,15 @@ struct comm_message
 /**
  * @brief Builds a new communication requisition.
  *
- * @param cid Request context.
- * @param src Request src.
- * @param tag Request tag.
- * @param req Request reference to be initialized.
+ * @param cid    Request context.
+ * @param src    Request src.
+ * @param target Request target.
+ * @param tag    Request tag.
+ * @param req    Request reference to be initialized.
  *
  * @todo Add a hash function to make requests comparation quicker.
  */
-extern void comm_request_build(int cid, int src, int tag, struct comm_request *req);
-
-/**
- * @brief Allocates a new request and registers it in the requisitions queue.
- *
- * @param msg Requisition to be registered.
- *
- * @returns Upon successful completion, zero is returned. Upon failure, a negative
- * error code is returned instead.
- *
- * @todo Implement this function.
- *
- * @note This function needs to copy the req attributes in a safe structure, not only
- * storing its reference.
- */
-extern int comm_request_register(struct comm_message *msg);
+extern void comm_request_build(int cid, int src, int target, int tag, struct comm_request *req);
 
 /**
  * @brief Search into Request Queue.
@@ -102,15 +94,14 @@ extern int comm_request_register(struct comm_message *msg);
 extern int comm_request_search(struct comm_message *msg);
 
 /**
- * @brief Compares if two communication requisitions are equal.
+ * @brief Receives a new communication request from the IKC facility.
  *
- * @param req1 First requisition to be compared.
- * @param req2 Second requisition.
+ * @param msg Message holder with a valid request information.
  *
- * @returns Returns ZERO if the requisitions are different and a NON-ZERO value if
- * they match correctly.
+ * @returns Upon successful completion, zero is returned with the received message
+ * copied into @p msg. Upon failure, a negative error code is returned instead.
  */
-extern int comm_request_match(struct comm_request *req1, struct comm_request *req2);
+extern int comm_request_receive(struct comm_message *msg);
 
 /**
  * @brief Initializes the requests submodule.

--- a/include/mputil/comm_request.h
+++ b/include/mputil/comm_request.h
@@ -25,10 +25,12 @@
 #ifndef NANVIX_COMM_REQUEST_H_
 #define NANVIX_COMM_REQUEST_H_
 
+#include <nanvix/kernel/mailbox.h>
+
 /**
  * @brief Predefined port number that is used to receive communication requests.
  */
-#define COMM_REQ_RECV_PORT 15
+#define COMM_REQ_RECV_PORT (KMAILBOX_PORT_NR - 1)
 
 /**
  * @brief Struct that defines a basic communication request.
@@ -53,9 +55,11 @@ struct comm_message
 	{
 		struct
 		{
-			uint16_t datatype;   /**< Datatype.     */
-			size_t size;         /**< Message size. */
-			uint8_t portal_port; /**< Port Number.  */
+			uint16_t datatype;   /**< Datatype.          */
+			size_t size;         /**< Message size.      */
+			uint8_t portal_port; /**< Port Number.       */
+			uint8_t inbox_port;  /**< Inbox Port Number. */
+			uint8_t nodenum;     /**< Node Number.       */
 		} send;
 
 		struct

--- a/include/mputil/comm_request.h
+++ b/include/mputil/comm_request.h
@@ -54,6 +54,11 @@ struct comm_message
 
 		struct
 		{
+			uint8_t mailbox_port; /**< Outbox port_nr. */
+		} confirm;
+
+		struct
+		{
 			int errcode; /* Function return. */
 		} ret;
 	} msg;

--- a/include/mputil/communication.h
+++ b/include/mputil/communication.h
@@ -74,7 +74,7 @@ extern int comm_context_finalize(void);
 /**
  * @todo Provide a detailed description.
  */
-extern int send(int cid, const void *buf, size_t size, mpi_process_t *dest, int datatype, int tag, int mode);
+extern int send(int cid, const void *buf, size_t size, int src, mpi_process_t *dest, int datatype, int tag, int mode);
 
 /**
  * @todo Provide a detailed description.

--- a/include/mputil/communication.h
+++ b/include/mputil/communication.h
@@ -25,7 +25,6 @@
 #ifndef NANVIX_COMM_CONTEXT_H_
 #define NANVIX_COMM_CONTEXT_H_
 
-#include <nanvix/limits.h>
 #include <mputil/proc.h>
 #include <mputil/comm_request.h>
 

--- a/include/mputil/communication.h
+++ b/include/mputil/communication.h
@@ -74,11 +74,13 @@ extern int comm_context_finalize(void);
 /**
  * @todo Provide a detailed description.
  */
-extern int send(int cid, const void *buf, size_t size, int src, mpi_process_t *dest, int datatype, int tag, int mode);
+extern int send(int cid, const void *buf, size_t size, int src, int dest,
+	            mpi_process_t *dest_proc, int datatype, int tag, int mode);
 
 /**
  * @todo Provide a detailed description.
  */
-extern int recv(int cid, void *buf, size_t size, mpi_process_t *src, int datatype, struct comm_request *req);
+extern int recv(int cid, void *buf, size_t size, mpi_process_t *src, int datatype,
+	            struct comm_request *req);
 
 #endif /* NANVIX_COMM_CONTEXT_H_ */

--- a/include/mputil/proc.h
+++ b/include/mputil/proc.h
@@ -43,6 +43,10 @@
 #define MPI_PROCESSES_NR (MPI_NODES_NR * 2)
 #endif
 
+#define MPI_PROCS_PER_CLUSTER_MAX ((MPI_PROCESSES_NR / MPI_NODES_NR) +                \
+                                   ((MPI_PROCESSES_NR % MPI_NODES_NR == 0) ? 0 : 1)   \
+                                  )
+
 /**
  * @brief Base compensation for clusters know their local mpi_id.
  */
@@ -58,11 +62,11 @@
  */
 struct mpi_process_t
 {
-	object_t super; /* Base object class.     */
+	object_t super; /* Base object class.    */
 
 	char name[NANVIX_PROC_NAME_MAX];
-	int pid;        /* Process ID.            */
-	int tid;        /* Vinculated thread ID.  */
+	int pid;        /* Process ID.           */
+	int tid;        /* Vinculated thread ID. */
 	int inbox;
 	int inportal;
 };
@@ -90,6 +94,14 @@ static inline const char * process_name(mpi_process_t *proc)
  * @returns Pointer to the local process descriptor.
  */
 extern mpi_process_t * curr_mpi_proc(void);
+
+/**
+ * @brief Gets the current process index in the local cluster.
+ *
+ * @returns The index of the current MPI Process in the local processes
+ * table.
+ */
+extern int curr_mpi_proc_index(void);
 
 /**
  * @brief Gets reference pointer to the current MPI process.

--- a/include/mputil/proc.h
+++ b/include/mputil/proc.h
@@ -40,7 +40,7 @@
  * @brief Defines the number of active MPI_PROCESSES.
  */
 #ifndef MPI_PROCESSES_NR
-#define MPI_PROCESSES_NR (MPI_NODES_NR * 2)
+#define MPI_PROCESSES_NR (MPI_NODES_NR * 12)
 #endif
 
 #define MPI_PROCS_PER_CLUSTER_MAX ((MPI_PROCESSES_NR / MPI_NODES_NR) +                \

--- a/include/mputil/proc.h
+++ b/include/mputil/proc.h
@@ -40,7 +40,7 @@
  * @brief Defines the number of active MPI_PROCESSES.
  */
 #ifndef MPI_PROCESSES_NR
-#define MPI_PROCESSES_NR (MPI_NODES_NR * 1)
+#define MPI_PROCESSES_NR (MPI_NODES_NR * 2)
 #endif
 
 /**
@@ -192,5 +192,12 @@ extern int mpi_local_proc_init(void);
  * negative MPI error code is returned instead.
  */
 extern int mpi_local_proc_finalize(void);
+
+/**
+ * @brief Gets the number of locally present MPI processes.
+ *
+ * @returns The number of MPI processes that are locally present.
+ */
+extern int mpi_local_procs_nr(void);
 
 #endif /* NANVIX_PROCESS_H_ */

--- a/include/mputil/ptr_array.h
+++ b/include/mputil/ptr_array.h
@@ -25,7 +25,7 @@
 #ifndef NANVIX_POINTER_ARRAY_H_
 #define NANVIX_POINTER_ARRAY_H_
 
-#include <nanvix/hal.h>
+#include <nanvix/sys/mutex.h>
 #include <mputil/object.h>
 
 /**
@@ -33,15 +33,15 @@
  */
 struct pointer_array_t
 {
-	object_t super;       /* Base object class.                */
+	object_t super;           /* Base object class.                */
 
-	spinlock_t lock;      /* Lock resource.                    */
-	int32_t lowest_free;  /* Lowest free index (optimization). */
-	int32_t size;         /* List size.                        */
-	int32_t max_size;     /* Array max size.                   */
-	int32_t block_size;   /* block size for each allocation    */
-	uint64_t *used_bits;  /* Free bits array (optimization).   */
-	void **addr;          /* Array of object pointers.         */
+	struct nanvix_mutex lock; /* Lock resource.                    */
+	int32_t lowest_free;      /* Lowest free index (optimization). */
+	int32_t size;             /* List size.                        */
+	int32_t max_size;         /* Array max size.                   */
+	int32_t block_size;       /* block size for each allocation    */
+	uint64_t *used_bits;      /* Free bits array (optimization).   */
+	void **addr;              /* Array of object pointers.         */
 };
 
 typedef struct pointer_array_t pointer_array_t;
@@ -114,9 +114,9 @@ static inline void * pointer_array_get_item(pointer_array_t *array, int index)
 	if (!WITHIN(index, 0, array->max_size))
 		return NULL;
 
-	spinlock_lock(&array->lock);
+	nanvix_mutex_lock(&array->lock);
 		p = array->addr[index];
-	spinlock_unlock(&array->lock);
+	nanvix_mutex_unlock(&array->lock);
 
 	return p;
 }

--- a/include/mputil/ptr_array.h
+++ b/include/mputil/ptr_array.h
@@ -40,7 +40,6 @@ struct pointer_array_t
 	int32_t size;             /* List size.                        */
 	int32_t max_size;         /* Array max size.                   */
 	int32_t block_size;       /* block size for each allocation    */
-	uint64_t *used_bits;      /* Free bits array (optimization).   */
 	void **addr;              /* Array of object pointers.         */
 };
 

--- a/makefile
+++ b/makefile
@@ -49,6 +49,9 @@ export SUPPRESS_TESTS ?= no
 # Extras
 export ADDONS ?=
 
+# Uses LWMPI?
+export NANVIX_LWMPI ?= 1
+
 #===============================================================================
 # Directories
 #===============================================================================
@@ -104,6 +107,9 @@ export CFLAGS += $(ADDONS)
 
 # Enable sync and portal implementation that uses mailboxes
 export CFLAGS += -D__NANVIX_IKC_USES_ONLY_MAILBOX=0
+
+# Enable LWMPI environment setup
+export CFLAGS += -D__NANVIX_USES_LWMPI=$(NANVIX_LWMPI)
 
 # Additional C Flags
 include $(BUILDDIR)/makefile.cflags

--- a/src/mpi/communicator/comm_rank.c
+++ b/src/mpi/communicator/comm_rank.c
@@ -39,18 +39,24 @@ static const char FUNC_NAME[] = "MPI_Comm_rank";
  */
 PUBLIC int MPI_Comm_rank(MPI_Comm comm, int *rank)
 {
+	int ret;
+
 	/* Parameters checking. */
 	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
 
 	/* Bad communicator. */
 	if (!mpi_comm_is_valid(comm))
-		return (MPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME));
+		ret = MPI_ERR_COMM;
 
 	/* Bad rank holder. */
 	if (rank == NULL)
-		return (MPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME));
+		ret = MPI_ERR_ARG;
 
-	*rank = mpi_comm_rank((mpi_communicator_t *) comm);
+	/* Retrieves the current process rank from the given communicator. */
+	ret = mpi_comm_rank((mpi_communicator_t *) comm, rank);
+
+	/* Checks if there was an error and calls an error handler case positive. */
+	MPI_ERRHANDLER_CHECK(ret, MPI_COMM_WORLD, ret, FUNC_NAME);
 
 	return (MPI_SUCCESS);
 }

--- a/src/mpi/communicator/communicator.c
+++ b/src/mpi/communicator/communicator.c
@@ -188,7 +188,7 @@ PUBLIC int mpi_comm_init(void)
 		return (MPI_ERR_NO_MEM);
 
 	mpi_group_increment_proc_count(group);
-	mpi_group_set_rank(group, process_local());
+	mpi_group_set_rank(group, curr_mpi_proc());
 
 	_mpi_comm_world.group         = group;
 	_mpi_comm_world.my_rank       = group->my_rank;
@@ -205,7 +205,7 @@ PUBLIC int mpi_comm_init(void)
 		return (MPI_ERR_NO_MEM);
 
 	mpi_group_increment_proc_count(group);
-	mpi_group_set_rank(group, process_local());
+	mpi_group_set_rank(group, curr_mpi_proc());
 
 	_mpi_comm_self.group         = group;
 	_mpi_comm_self.my_rank       = group->my_rank;

--- a/src/mpi/communicator/communicator.c
+++ b/src/mpi/communicator/communicator.c
@@ -48,7 +48,6 @@ PRIVATE void mpi_comm_construct(mpi_communicator_t * comm)
 	uassert(comm != NULL);
 
 	comm->group           = NULL;
-	comm->my_rank         = MPI_UNDEFINED;
 	comm->pt2pt_cid       = MPI_UNDEFINED;
 	comm->coll_cid        = MPI_UNDEFINED;
 	comm->error_handler   = NULL;
@@ -186,10 +185,8 @@ PUBLIC int mpi_comm_init(void)
 		return (MPI_ERR_NO_MEM);
 
 	mpi_group_increment_proc_count(group);
-	mpi_group_set_rank(group, curr_mpi_proc());
 
 	_mpi_comm_world.group         = group;
-	_mpi_comm_world.my_rank       = group->my_rank;
 	_mpi_comm_world.pt2pt_cid     = 0;
 	_mpi_comm_world.coll_cid      = 1;
 	_mpi_comm_world.error_handler = MPI_ERRORS_ARE_FATAL;
@@ -203,10 +200,8 @@ PUBLIC int mpi_comm_init(void)
 		return (MPI_ERR_NO_MEM);
 
 	mpi_group_increment_proc_count(group);
-	mpi_group_set_rank(group, curr_mpi_proc());
 
 	_mpi_comm_self.group         = group;
-	_mpi_comm_self.my_rank       = group->my_rank;
 	_mpi_comm_self.pt2pt_cid     = 2;
 	_mpi_comm_self.coll_cid      = MPI_UNDEFINED;
 	_mpi_comm_self.error_handler = MPI_ERRORS_ARE_FATAL;
@@ -216,7 +211,6 @@ PUBLIC int mpi_comm_init(void)
 	OBJ_CONSTRUCT(&_mpi_comm_null, mpi_communicator_t);
 	_mpi_comm_null.group         = MPI_GROUP_NULL;
 	OBJ_RETAIN(_mpi_comm_null.group);
-	_mpi_comm_null.my_rank       = MPI_PROC_NULL;
 	_mpi_comm_null.error_handler = MPI_ERRORS_ARE_FATAL;
 	OBJ_RETAIN(_mpi_comm_null.error_handler);
 	

--- a/src/mpi/communicator/communicator.c
+++ b/src/mpi/communicator/communicator.c
@@ -22,12 +22,10 @@
  * SOFTWARE.
  */
 
-#include <nanvix/hlib.h>
 #include <nanvix/ulib.h>
-#include <posix/errno.h>
 #include <mpi/communicator.h>
 #include <mpi/mpiruntime.h>
-#include <mputil/comm_context.h>
+#include <mputil/communication.h>
 
 PRIVATE void mpi_comm_construct(mpi_communicator_t *);
 PRIVATE void mpi_comm_destruct(mpi_communicator_t *);

--- a/src/mpi/datatype/datatype.c
+++ b/src/mpi/datatype/datatype.c
@@ -24,7 +24,6 @@
 
 #include <nanvix/hlib.h>
 #include <nanvix/ulib.h>
-#include <posix/errno.h>
 #include <mpi/datatype.h>
 
 PRIVATE void mpi_datatype_construct(mpi_datatype_t *);

--- a/src/mpi/errhandler/errhandler_predefined.c
+++ b/src/mpi/errhandler/errhandler_predefined.c
@@ -186,12 +186,12 @@ static void print_error_message(int *errcode, va_list arglist)
 	{
 		if (arg == NULL)
 		{
-			uprintf("ERROR!!! A function was called after MPI_Finalize() was invoked, what" \
+			uprintf("ERROR!!! A function was called after MPI_Finalize() was invoked, what " \
 			        "is not allowed by the MPI standard.");
 		}
 		else
 		{
-			uprintf("ERROR!!! %s() function called after MPI_Finalize() was invoked, what" \
+			uprintf("ERROR!!! %s() function called after MPI_Finalize() was invoked, what " \
 			        "is not allowed by the MPI standard.", arg);
 		}
 	}
@@ -203,7 +203,12 @@ static void print_error_message(int *errcode, va_list arglist)
 			uprintf("ERROR!!! %s", arg);
 
 		if (errcode != NULL)
-			uprintf("Error code: %d", *errcode);
+		{
+			if ((*errcode) < 0)
+				uprintf("Error code: -%d", -(*errcode));
+			else
+				uprintf("Error code: %d", *errcode);
+		}
 	}
 
 	va_end(arglist);

--- a/src/mpi/errhandler/errhandler_predefined.c
+++ b/src/mpi/errhandler/errhandler_predefined.c
@@ -22,9 +22,7 @@
  * SOFTWARE.
  */
 
-#include <nanvix/hlib.h>
 #include <nanvix/ulib.h>
-#include <posix/errno.h>
 #include <mpi/errhandler_predefined.h>
 #include <mpi/communicator.h>
 #include <mpi/mpiruntime.h>

--- a/src/mpi/group/group.c
+++ b/src/mpi/group/group.c
@@ -22,9 +22,7 @@
  * SOFTWARE.
  */
 
-#include <nanvix/hlib.h>
 #include <nanvix/ulib.h>
-#include <posix/errno.h>
 #include <mpi/group.h>
 
 PRIVATE void mpi_group_construct(mpi_group_t *);

--- a/src/mpi/group/group_rank.c
+++ b/src/mpi/group/group_rank.c
@@ -48,8 +48,6 @@ PUBLIC int MPI_Group_rank(MPI_Group group, int *rank)
 	/* Parameters checking. */
 	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
 
-	ret = MPI_SUCCESS;
-
 	/* Bad group. */
 	if (!mpi_group_is_valid(group))
 		ret = MPI_ERR_GROUP;
@@ -58,10 +56,11 @@ PUBLIC int MPI_Group_rank(MPI_Group group, int *rank)
 	if (rank == NULL)
 		ret = MPI_ERR_ARG;
 
+	/* Retrieves the current process rank from the given group. */
+	ret = mpi_group_rank((mpi_group_t *) group, rank);
+
 	/* Checks if there was an error and calls an error handler case positive. */
 	MPI_ERRHANDLER_CHECK(ret, MPI_COMM_WORLD, ret, FUNC_NAME);
-
-	*rank = mpi_group_rank((mpi_group_t *) group);
 
 	return (MPI_SUCCESS);
 }

--- a/src/mpi/pt2pt/pt2pt_comm.c
+++ b/src/mpi/pt2pt/pt2pt_comm.c
@@ -23,7 +23,7 @@
  */
 
 #include <nanvix/runtime/pm.h>
-#include <mputil/comm_context.h>
+#include <mputil/communication.h>
 #include <mputil/comm_request.h>
 #include <mpi/pt2pt_comm.h>
 #include <mpi/communicator.h>

--- a/src/mpi/pt2pt/pt2pt_comm.c
+++ b/src/mpi/pt2pt/pt2pt_comm.c
@@ -59,7 +59,7 @@ PUBLIC int mpi_send(const void *buf, int count, MPI_Datatype datatype, int dest,
 	/* Gets the datatype id. */
 	datatype_id = mpi_datatype_id(datatype);
 
-	ret = send(cid, buf, size, src, dest_proc, datatype_id, tag, mode);
+	ret = send(cid, buf, size, src, dest, dest_proc, datatype_id, tag, mode);
 
 end:
 	return (ret);
@@ -73,6 +73,7 @@ PUBLIC int mpi_recv(void *buf, int count, MPI_Datatype datatype, int source,
 {
 	int ret;
 	int cid;
+	int rank;
 	size_t size;
 	int datatype_id;
 	mpi_process_t *src_proc;
@@ -91,10 +92,15 @@ PUBLIC int mpi_recv(void *buf, int count, MPI_Datatype datatype, int source,
 	/* Gets the datatype id. */
 	datatype_id = mpi_datatype_id(datatype);
 
+	/* Gets the local process rank. */
+	if ((ret = mpi_comm_rank((mpi_communicator_t *) comm, &rank)) != MPI_SUCCESS)
+		return (ret);
+
 	/* Builds the recv request to be compared in the underlying function. */
-	request.cid = cid;
-	request.src = source;
-	request.tag = tag;
+	request.cid    = cid;
+	request.src    = source;
+	request.target = rank;
+	request.tag    = tag;
 
 	ret = recv(cid, buf, size, src_proc, datatype_id, &request);
 

--- a/src/mpi/runtime/finalize.c
+++ b/src/mpi/runtime/finalize.c
@@ -43,8 +43,14 @@ static const char FUNC_NAME[] = "MPI_Finalize";
  */
 PUBLIC int MPI_Finalize(void)
 {
-	/* Checks if MPI is in a valid state. */
-	MPI_CHECK_INIT_FINALIZE(FUNC_NAME);
+	UNUSED(FUNC_NAME);
 
+	/**
+	 * @brief This function is only a wrapper and goes directly to the underlying
+	 * implementation.
+	 *
+	 * @note All security checks relating to the runtime state are executed in
+	 * the underlying function, according to the process type (emulated or not).
+	 */
 	return (mpi_finalize());
 }

--- a/src/mpi/runtime/runtime.c
+++ b/src/mpi/runtime/runtime.c
@@ -224,6 +224,9 @@ PUBLIC int mpi_finalize(void)
 {
 	int ret;
 
+	/* Fence to ensure that all threads called finalize in the local cluster. */
+	uassert(mpi_std_fence() == 0);
+
 	/* The master thread exclusively executes the cleanup. */
 	if (!curr_proc_is_master())
 		goto slaves;

--- a/src/mpi/runtime/runtime.c
+++ b/src/mpi/runtime/runtime.c
@@ -59,6 +59,10 @@ PUBLIC int mpi_init(int argc, char **argv)
 	if (!curr_proc_is_master())
 		goto slave;
 
+#if DEBUG
+	uprintf("%s as master of the cluster...", process_name(curr_mpi_proc()));
+#endif /* DEBUG */
+
 	/* Initializes runtime mutex. */
 	uassert(nanvix_mutex_init(&_runtime_lock, NULL) == 0);
 
@@ -182,16 +186,16 @@ end:
 	return (ret);
 
 slave:
+	/* First fence to ensure that local processes were correctly initialized. */
+	uassert(mpi_std_fence() == 0);
+
+#if DEBUG
+	uprintf("%s preparing to initialize local structures...", process_name(curr_mpi_proc()));
+#endif /* DEBUG */
+
 	/* Initialize std structures for spawned threads. */
 	uassert(__stdmailbox_setup() == 0);
 	uassert(__stdportal_setup() == 0);
-
-#if DEBUG
-	uprintf("%s waiting in first fence...", process_name(curr_mpi_proc()));
-#endif /* DEBUG */
-
-	/* First fence to ensure that local processes were correctly initialized. */
-	uassert(mpi_std_fence() == 0);
 
 #if DEBUG
 	uprintf("%s initializing local structures...", process_name(curr_mpi_proc()));

--- a/src/mpi/runtime/runtime.c
+++ b/src/mpi/runtime/runtime.c
@@ -23,7 +23,7 @@
  */
 
 #include <mputil/proc.h>
-#include <mputil/comm_context.h>
+#include <mputil/communication.h>
 #include <mputil/comm_request.h>
 #include <mpi/mpiruntime.h>
 #include <mpi/errhandler.h>

--- a/src/mpi/runtime/runtime.c
+++ b/src/mpi/runtime/runtime.c
@@ -60,7 +60,7 @@ PUBLIC int mpi_init(int argc, char **argv)
 		goto slave;
 
 	/* Initializes runtime mutex. */
-	uassert(nanvix_mutex_init(&_runtime_lock) == 0);
+	uassert(nanvix_mutex_init(&_runtime_lock, NULL) == 0);
 
 	/* Locks the runtime to evaluate mpi_state. */
 	nanvix_mutex_lock(&_runtime_lock);

--- a/src/mputil/comm_request.c
+++ b/src/mputil/comm_request.c
@@ -114,8 +114,6 @@ PUBLIC int comm_request_match(struct comm_request *req1, struct comm_request *re
  * @returns Upon successful completion, zero is returned. Upon failure, a negative
  * error code is returned instead.
  *
- * @todo Implement this function.
- *
  * @note This function needs to copy the msg attributes in a safe structure, not only
  * storing its reference.
  */

--- a/src/mputil/comm_request.c
+++ b/src/mputil/comm_request.c
@@ -45,7 +45,7 @@
 /**
  * @brief Maximum size of request queue.
  */
-#define RQUEUE_MAX_SIZE 32
+#define RQUEUE_MAX_SIZE 256
 
 /**
  * @brief Request queue node structure.
@@ -253,12 +253,20 @@ again:
 	/* Gets the pointer to the allocated node. */
 	node = &rnodes[id];
 
+#if DEBUG
+	uprintf("%s waiting in its inbox...", process_name(curr_mpi_proc()));
+#endif /* DEBUG */
+
 	/* Waits for a send request. */
 	if (kmailbox_read(_inbox, &node->msg, sizeof(struct comm_message)) < 0)
 	{
 		ret = (-MPI_ERR_UNKNOWN);
 		goto desoccupy;
 	}
+
+#if DEBUG
+	uprintf("Request arrived from process %d to process %d", node->msg.req.src, node->msg.req.target);
+#endif /* DEBUG */
 
 	/* Checks if the expected and received requests match. */
 	if (!comm_request_match(&msg->req, &node->msg.req))

--- a/src/mputil/communication.c
+++ b/src/mputil/communication.c
@@ -24,8 +24,7 @@
 
 #include <nanvix/ulib.h>
 #include <nanvix/runtime/pm.h>
-#include <nanvix/sys/mailbox.h>
-#include <mputil/comm_context.h>
+#include <mputil/communication.h>
 #include <mpi/datatype.h>
 #include <mpi/mpi_errors.h>
 
@@ -69,7 +68,7 @@ PRIVATE void request_header_build(struct comm_message *m, uint16_t cid, uint16_t
  *============================================================================*/
 
 /**
- * @see comm_context_allocate in comm_context.h.
+ * @see comm_context_allocate in communication.h.
  *
  * @todo Implement this function like described in the header file.
  */
@@ -79,7 +78,7 @@ PUBLIC int comm_context_allocate(void)
 }
 
 /**
- * @see comm_context_init in comm_context.h.
+ * @see comm_context_init in communication.h.
  */
 PUBLIC int comm_context_init(void)
 {
@@ -117,7 +116,7 @@ PUBLIC int comm_context_init(void)
 }
 
 /**
- * @see comm_context_finalize in comm_context.h.
+ * @see comm_context_finalize in communication.h.
  */
 PUBLIC int comm_context_finalize(void)
 {

--- a/src/mputil/communication.c
+++ b/src/mputil/communication.c
@@ -85,7 +85,7 @@ PUBLIC int comm_context_allocate(void)
  */
 PUBLIC int comm_context_init(void)
 {
-	uassert(nanvix_mutex_init(&_recv_lock) == 0);
+	uassert(nanvix_mutex_init(&_recv_lock, NULL) == 0);
 
 	return (0);
 }

--- a/src/mputil/proc.c
+++ b/src/mputil/proc.c
@@ -401,11 +401,19 @@ PUBLIC int __mpi_processes_init(int(*fn)(int, const char *[]), int argc, const c
 		/* Initializes the local processes list and create the threads that will run them. */
 		for (int i = 1, id = (first_pid + MPI_NODES_NR); id < _processes_nr; id += MPI_NODES_NR, ++i)
 		{
+#if DEBUG
+			uprintf("Spawning mpi-process-%d", id);
+#endif /* DEBUG */
+
 			_local_processes[i] = (mpi_process_t *) pointer_array_get_item(&_processes_list, id);
 			uassert(_local_processes[i] != NULL);
 
 			/* Creates a thread to emulate an MPI process. */
 			uassert(kthread_create(&tid, &_main3_wrapper, NULL) == 0);
+
+#if DEBUG
+			uprintf("mpi-process-%d TID: %d", id, tid);
+#endif /* DEBUG */
 
 			_local_processes[i]->tid = tid;
 
@@ -479,8 +487,8 @@ PUBLIC int mpi_local_proc_init(void)
 	curr_proc->inportal = portalid;
 
 #if DEBUG
-	uprintf("%s inbox: %d", curr_proc_name, mbxid);
-	uprintf("%s inportal: %d", curr_proc_name, portalid);
+	uprintf("%s inbox port: %d", curr_proc_name, nanvix_mailbox_get_port(mbxid));
+	uprintf("%s inportal port: %d", curr_proc_name, nanvix_portal_get_port(portalid));
 #endif /* DEBUG */
 
 	return (0);

--- a/src/test/mpi.c
+++ b/src/test/mpi.c
@@ -64,7 +64,7 @@ PRIVATE void test_mpi_before_init(void)
  */
 PRIVATE void test_mpi_init(void)
 {
-	uassert(MPI_Init(&_argc, &_argv) >= 0);
+	uassert(MPI_Init(&_argc, &_argv) == 0);
 }
 
 /**
@@ -168,6 +168,10 @@ PRIVATE void test_mpi_comm_pairs(void)
 #endif
 
 		uassert(MPI_Recv(&inbuffer, 1, MPI_INT, remote, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE) == MPI_SUCCESS);
+
+#if TEST_VERBOSE
+		uprintf("Received!");
+#endif
 	}
 	else
 	{
@@ -184,6 +188,10 @@ PRIVATE void test_mpi_comm_pairs(void)
 #endif
 
 		uassert(MPI_Send(&outbuffer, 1, MPI_INT, remote, 0, MPI_COMM_WORLD) == MPI_SUCCESS);
+
+#if TEST_VERBOSE
+		uprintf("Sent!");
+#endif
 	}
 
 	uassert(inbuffer == remote);
@@ -227,6 +235,10 @@ PRIVATE void test_mpi_comm_req_queue(void)
 
 			uassert(MPI_Recv(&inbuffer, 1, MPI_INT, remote, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE) == MPI_SUCCESS);
 			uassert(inbuffer == remote);
+
+#if TEST_VERBOSE
+			uprintf("Received!");
+#endif
 		}
 
 		/* Reads even ranks. */
@@ -238,6 +250,10 @@ PRIVATE void test_mpi_comm_req_queue(void)
 
 			uassert(MPI_Recv(&inbuffer, 1, MPI_INT, remote, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE) == MPI_SUCCESS);
 			uassert(inbuffer == remote);
+
+#if TEST_VERBOSE
+			uprintf("Received!");
+#endif
 		}
 	}
 	else
@@ -249,6 +265,10 @@ PRIVATE void test_mpi_comm_req_queue(void)
 #endif
 
 		uassert(MPI_Send(&outbuffer, 1, MPI_INT, remote, 0, MPI_COMM_WORLD) == MPI_SUCCESS);
+
+#if TEST_VERBOSE
+		uprintf("Sent!");
+#endif
 	}
 
 #if TEST_VERBOSE

--- a/src/test/mpi.c
+++ b/src/test/mpi.c
@@ -22,7 +22,6 @@
  * SOFTWARE.
  */
 
-#include <nanvix/hal.h>
 #include <nanvix/sys/noc.h>
 #include <nanvix/ulib.h>
 #include <nanvix/config.h>


### PR DESCRIPTION
# Description #
In this PR, we reimplemented the LWMPI core to support multiple MPI processes per cluster, instead of a single process per cluster. We achieve this by emulating MPI processes with regular user threads exposed by the Nanvix Thread System.
Important changes introduced in this version are:
- The master thread of each cluster spawns multiple threads during runtime setup to emulate the MPI processes, and joins them in the finalization;
- Processes are identified by the Thread ID associated with them, instead of their cluster number;
- Contexts became an attribute sent in the messages header, while port numbers are now associated with their respective threads to compose the address of each MPI process;
- Comm Requests arrive at a centralized mailbox for all MPI processes inside the clusters, and are consumed or stored based on which process received them from the interconnection;
- Besides from being distinct processes from the point of view of the user, MPI internal structures are shared between the threads that are in the same cluster to reduce memory consumption;
- Finally, the Point-to-point communication protocol was reworked to reduce the overheads involved in the communications and to reduce the workload over the communication abstractions. For example, receivers does not need to realize an address lookup anymore, since these informations are sent by the senders in the handshake message headers.

Additionally, some small changes related to code styling and conventions were also made and included in this PR.

## Related Issues ##
 